### PR TITLE
[BLD] Test blacksmith runners for windows builds

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,19 @@
+# Configuration for actionlint
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+
+self-hosted-runner:
+  # Labels for Blacksmith runners and GitHub large runners
+  labels:
+    - blacksmith-2vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2404-arm
+    - blacksmith-8vcpu-ubuntu-2404
+    - blacksmith-16vcpu-ubuntu-2404
+    - blacksmith-16vcpu-ubuntu-2404-arm
+    - blacksmith-32vcpu-ubuntu-2404
+    - blacksmith-4vcpu-windows-2025
+    - blacksmith-8vcpu-windows-2025
+    - blacksmith-staging-4vcpu-windows-2025
+    - blacksmith-staging-8vcpu-windows-2025
+    - bs-dev-taha
+    - 8core-32gb-windows-2025

--- a/.github/workflows/_build_js_bindings.yml
+++ b/.github/workflows/_build_js_bindings.yml
@@ -75,7 +75,7 @@ jobs:
 
   build-windows:
     name: Build Windows bindings
-    runs-on: 8core-32gb-windows-latest
+    runs-on: blacksmith-8vcpu-windows-2025
     defaults:
       run:
         working-directory: rust/js_bindings

--- a/.github/workflows/_build_js_bindings.yml
+++ b/.github/workflows/_build_js_bindings.yml
@@ -9,8 +9,8 @@ permissions:
 "on":
   workflow_dispatch: {}
   schedule:
-    # Run every hour for testing Windows runners
-    - cron: '0 * * * *'
+    # TEMPORARY: Run every 30 minutes for benchmarking/testing Blacksmith Windows runners
+    - cron: '*/30 * * * *'
   workflow_call: {}
 jobs:
   # build-macos:

--- a/.github/workflows/_build_js_bindings.yml
+++ b/.github/workflows/_build_js_bindings.yml
@@ -76,8 +76,9 @@ jobs:
   build-windows:
     name: Build Windows bindings
     runs-on:
-      - blacksmith-staging-8vcpu-windows-2025
-      - bs-dev-taha
+      # - blacksmith-staging-8vcpu-windows-2025
+      # - bs-dev-taha
+      - windows-2025
     defaults:
       run:
         working-directory: rust/js_bindings

--- a/.github/workflows/_build_js_bindings.yml
+++ b/.github/workflows/_build_js_bindings.yml
@@ -2,76 +2,76 @@ name: JS Bindings CI
 env:
   DEBUG: napi:*
   APP_NAME: "chromadb-js-bindings"
-  MACOSX_DEPLOYMENT_TARGET: '10.13'
+  MACOSX_DEPLOYMENT_TARGET: "10.13"
 permissions:
   contents: write
   id-token: write
-'on':
+"on":
   workflow_dispatch: {}
   workflow_call: {}
 jobs:
-  build-macos:
-    name: Build macOS bindings
-    runs-on: macos-latest
-    defaults:
-      run:
-        working-directory: rust/js_bindings
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          run_install: false
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: rust/js_bindings/pnpm-lock.yaml
-      - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Add targets
-        run: |
-          rustup target add x86_64-apple-darwin
-          rustup target add aarch64-apple-darwin
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            rust/js_bindings/.cargo-cache
-            rust/js_bindings/target/
-          key: macos-cargo
-      - name: Install dependencies
-        run: pnpm install
-      - name: Build ARM64
-        run: pnpm build --target aarch64-apple-darwin
-        shell: bash
-      - name: Build x86_64
-        run: pnpm build --target x86_64-apple-darwin
-        shell: bash
-      - name: Upload ARM64 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: bindings-aarch64-apple-darwin
-          path: rust/js_bindings/chromadb-js-bindings.darwin-arm64.node
-          if-no-files-found: error
-      - name: Upload x86_64 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: bindings-x86_64-apple-darwin
-          path: rust/js_bindings/chromadb-js-bindings.darwin-x64.node
-          if-no-files-found: error
+  # build-macos:
+  #   name: Build macOS bindings
+  #   runs-on: macos-latest
+  #   defaults:
+  #     run:
+  #       working-directory: rust/js_bindings
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Install pnpm
+  #       uses: pnpm/action-setup@v4
+  #       with:
+  #         version: 9
+  #         run_install: false
+  #     - name: Setup node
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 20
+  #         cache: pnpm
+  #         cache-dependency-path: rust/js_bindings/pnpm-lock.yaml
+  #     - name: Set up Rust toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         override: true
+  #     - name: Install Protoc
+  #       uses: arduino/setup-protoc@v3
+  #       with:
+  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Add targets
+  #       run: |
+  #         rustup target add x86_64-apple-darwin
+  #         rustup target add aarch64-apple-darwin
+  #     - name: Cache cargo
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: |
+  #           ~/.cargo/registry/index/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/git/db/
+  #           rust/js_bindings/.cargo-cache
+  #           rust/js_bindings/target/
+  #         key: macos-cargo
+  #     - name: Install dependencies
+  #       run: pnpm install
+  #     - name: Build ARM64
+  #       run: pnpm build --target aarch64-apple-darwin
+  #       shell: bash
+  #     - name: Build x86_64
+  #       run: pnpm build --target x86_64-apple-darwin
+  #       shell: bash
+  #     - name: Upload ARM64 artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: bindings-aarch64-apple-darwin
+  #         path: rust/js_bindings/chromadb-js-bindings.darwin-arm64.node
+  #         if-no-files-found: error
+  #     - name: Upload x86_64 artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: bindings-x86_64-apple-darwin
+  #         path: rust/js_bindings/chromadb-js-bindings.darwin-x64.node
+  #         if-no-files-found: error
 
   build-windows:
     name: Build Windows bindings
@@ -126,133 +126,133 @@ jobs:
           path: rust/js_bindings/chromadb-js-bindings.win32-x64-msvc.node
           if-no-files-found: error
 
-  build-linux:
-    name: Build Linux bindings
-    runs-on: blacksmith-16vcpu-ubuntu-2404
-    defaults:
-      run:
-        working-directory: rust/js_bindings
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          run_install: false
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: rust/js_bindings/pnpm-lock.yaml
-      - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Add targets
-        run: |
-          rustup target add x86_64-unknown-linux-gnu
-          rustup target add aarch64-unknown-linux-gnu
-      - name: Install ARM64 cross-compilation tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            gcc-aarch64-linux-gnu \
-            g++-aarch64-linux-gnu \
-            libc6-dev-arm64-cross
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            rust/js_bindings/.cargo-cache
-            rust/js_bindings/target/
-          key: linux-cargo
-      - name: Install dependencies
-        run: pnpm install
-      - name: Build ARM64
-        run: |
-          # Set linker and compiler environment variables
-          export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
-          export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
-          export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
-          # Add no_asm flag to avoid assembly issues
-          export RUSTFLAGS="--cfg no_asm"
-          # Build with the correct environment
-          pnpm build --target aarch64-unknown-linux-gnu
-        shell: bash
-      - name: Build x86_64
-        run: pnpm build --target x86_64-unknown-linux-gnu
-        shell: bash
-      - name: Upload ARM64 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: bindings-aarch64-unknown-linux-gnu
-          path: rust/js_bindings/chromadb-js-bindings.linux-arm64-gnu.node
-          if-no-files-found: error
-      - name: Upload x86_64 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: bindings-x86_64-unknown-linux-gnu
-          path: rust/js_bindings/chromadb-js-bindings.linux-x64-gnu.node
-          if-no-files-found: error
-  publish:
-    name: Publish
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: rust/js_bindings
-    needs:
-      - build-macos
-      - build-windows
-      - build-linux
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          run_install: false
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: rust/js_bindings/pnpm-lock.yaml
-      - name: Install dependencies
-        run: pnpm install
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: rust/js_bindings/artifacts
-      - name: List downloads
-        run: ls -R .
-      - name: Flatten artifact directory
-        run: find artifacts -type f -name '*.node' -exec mv {} ./artifacts/ \;
-      - name: List downloads
-        run: ls -R .
-      - name: Move artifacts
-        run: pnpm artifacts
-      - name: List packages
-        run: ls -R .
-        shell: bash
-      - name: Publish
-        run: |
-          set -e
-          npm config set provenance true
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-          for dir in npm/*; do
-            if [ -d "$dir" ]; then
-              cd "$dir" && npm publish --access public && cd -
-            fi
-          done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  # build-linux:
+  #   name: Build Linux bindings
+  #   runs-on: blacksmith-16vcpu-ubuntu-2404
+  #   defaults:
+  #     run:
+  #       working-directory: rust/js_bindings
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Install pnpm
+  #       uses: pnpm/action-setup@v4
+  #       with:
+  #         version: 9
+  #         run_install: false
+  #     - name: Setup node
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 20
+  #         cache: pnpm
+  #         cache-dependency-path: rust/js_bindings/pnpm-lock.yaml
+  #     - name: Set up Rust toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         override: true
+  #     - name: Install Protoc
+  #       uses: arduino/setup-protoc@v3
+  #       with:
+  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Add targets
+  #       run: |
+  #         rustup target add x86_64-unknown-linux-gnu
+  #         rustup target add aarch64-unknown-linux-gnu
+  #     - name: Install ARM64 cross-compilation tools
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install -y \
+  #           gcc-aarch64-linux-gnu \
+  #           g++-aarch64-linux-gnu \
+  #           libc6-dev-arm64-cross
+  #     - name: Cache cargo
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: |
+  #           ~/.cargo/registry/index/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/git/db/
+  #           rust/js_bindings/.cargo-cache
+  #           rust/js_bindings/target/
+  #         key: linux-cargo
+  #     - name: Install dependencies
+  #       run: pnpm install
+  #     - name: Build ARM64
+  #       run: |
+  #         # Set linker and compiler environment variables
+  #         export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+  #         export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+  #         export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
+  #         # Add no_asm flag to avoid assembly issues
+  #         export RUSTFLAGS="--cfg no_asm"
+  #         # Build with the correct environment
+  #         pnpm build --target aarch64-unknown-linux-gnu
+  #       shell: bash
+  #     - name: Build x86_64
+  #       run: pnpm build --target x86_64-unknown-linux-gnu
+  #       shell: bash
+  #     - name: Upload ARM64 artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: bindings-aarch64-unknown-linux-gnu
+  #         path: rust/js_bindings/chromadb-js-bindings.linux-arm64-gnu.node
+  #         if-no-files-found: error
+  #     - name: Upload x86_64 artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: bindings-x86_64-unknown-linux-gnu
+  #         path: rust/js_bindings/chromadb-js-bindings.linux-x64-gnu.node
+  #         if-no-files-found: error
+  # publish:
+  #   name: Publish
+  #   runs-on: ubuntu-latest
+  #   defaults:
+  #     run:
+  #       working-directory: rust/js_bindings
+  #   needs:
+  #     - build-macos
+  #     - build-windows
+  #     - build-linux
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Install pnpm
+  #       uses: pnpm/action-setup@v4
+  #       with:
+  #         version: 9
+  #         run_install: false
+  #     - name: Setup node
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 20
+  #         cache: pnpm
+  #         cache-dependency-path: rust/js_bindings/pnpm-lock.yaml
+  #     - name: Install dependencies
+  #       run: pnpm install
+  #     - name: Download all artifacts
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         path: rust/js_bindings/artifacts
+  #     - name: List downloads
+  #       run: ls -R .
+  #     - name: Flatten artifact directory
+  #       run: find artifacts -type f -name '*.node' -exec mv {} ./artifacts/ \;
+  #     - name: List downloads
+  #       run: ls -R .
+  #     - name: Move artifacts
+  #       run: pnpm artifacts
+  #     - name: List packages
+  #       run: ls -R .
+  #       shell: bash
+  #     - name: Publish
+  #       run: |
+  #         set -e
+  #         npm config set provenance true
+  #         echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+  #         for dir in npm/*; do
+  #           if [ -d "$dir" ]; then
+  #             cd "$dir" && npm publish --access public && cd -
+  #           fi
+  #         done
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/_build_js_bindings.yml
+++ b/.github/workflows/_build_js_bindings.yml
@@ -79,8 +79,8 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - [blacksmith-staging-4vcpu-windows-2025, bs-dev-taha]
-          - windows-2025
+          - blacksmith-staging-8vcpu-windows-2025
+          - 8core-32gb-windows-2025
     runs-on: ${{ matrix.runner }}
     defaults:
       run:
@@ -128,7 +128,7 @@ jobs:
       - name: Upload x86_64 artifact
         uses: actions/upload-artifact@v4
         with:
-          name: bindings-x86_64-pc-windows-msvc
+          name: bindings-x86_64-pc-windows-msvc-${{ matrix.runner == '8core-32gb-windows-2025' && 'github' || 'blacksmith' }}
           path: rust/js_bindings/chromadb-js-bindings.win32-x64-msvc.node
           if-no-files-found: error
 

--- a/.github/workflows/_build_js_bindings.yml
+++ b/.github/workflows/_build_js_bindings.yml
@@ -74,11 +74,14 @@ jobs:
   #         if-no-files-found: error
 
   build-windows:
-    name: Build Windows bindings
-    runs-on:
-      - blacksmith-staging-8vcpu-windows-2025
-      - bs-dev-taha
-      # - windows-2025
+    name: Build Windows bindings (${{ matrix.runner }})
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - [blacksmith-staging-4vcpu-windows-2025, bs-dev-taha]
+          - windows-2025
+    runs-on: ${{ matrix.runner }}
     defaults:
       run:
         working-directory: rust/js_bindings

--- a/.github/workflows/_build_js_bindings.yml
+++ b/.github/workflows/_build_js_bindings.yml
@@ -76,9 +76,9 @@ jobs:
   build-windows:
     name: Build Windows bindings
     runs-on:
-      # - blacksmith-staging-8vcpu-windows-2025
-      # - bs-dev-taha
-      - windows-2025
+      - blacksmith-staging-8vcpu-windows-2025
+      - bs-dev-taha
+      # - windows-2025
     defaults:
       run:
         working-directory: rust/js_bindings
@@ -97,9 +97,12 @@ jobs:
           cache-dependency-path: rust/js_bindings/pnpm-lock.yaml
       - name: Set up Rust toolchain
         uses: actions-rs/toolchain@v1
+        continue-on-error: true
         with:
           toolchain: stable
           override: true
+      - name: Sleep for debug
+        run: sleep 1000
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/_build_js_bindings.yml
+++ b/.github/workflows/_build_js_bindings.yml
@@ -8,6 +8,9 @@ permissions:
   id-token: write
 "on":
   workflow_dispatch: {}
+  schedule:
+    # Run every hour for testing Windows runners
+    - cron: '0 * * * *'
   workflow_call: {}
 jobs:
   # build-macos:

--- a/.github/workflows/_build_js_bindings.yml
+++ b/.github/workflows/_build_js_bindings.yml
@@ -75,7 +75,9 @@ jobs:
 
   build-windows:
     name: Build Windows bindings
-    runs-on: blacksmith-8vcpu-windows-2025
+    runs-on:
+      - blacksmith-staging-8vcpu-windows-2025
+      - bs-dev-taha
     defaults:
       run:
         working-directory: rust/js_bindings

--- a/.github/workflows/_build_js_bindings.yml
+++ b/.github/workflows/_build_js_bindings.yml
@@ -97,12 +97,9 @@ jobs:
           cache-dependency-path: rust/js_bindings/pnpm-lock.yaml
       - name: Set up Rust toolchain
         uses: actions-rs/toolchain@v1
-        continue-on-error: true
         with:
           toolchain: stable
           override: true
-      - name: Sleep for debug
-        run: sleep 1000
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -66,8 +66,12 @@ jobs:
       matrix:
         platform:
           - { os: linux, runner: blacksmith-4vcpu-ubuntu-2404, target: x86_64 }
-          - { os: linux, runner: blacksmith-4vcpu-ubuntu-2404-arm, target: aarch64 }
-          - { os: windows, runner: 8core-32gb-windows-latest, target: x64 }
+          - {
+              os: linux,
+              runner: blacksmith-4vcpu-ubuntu-2404-arm,
+              target: aarch64,
+            }
+          - { os: windows, runner: blacksmith-8vcpu-windows-2025, target: x64 }
           - { os: macos, runner: macos-14, target: x86_64 }
           - { os: macos, runner: macos-14, target: aarch64 }
 

--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -4,34 +4,34 @@ on:
   workflow_dispatch:
     inputs:
       publish_to_test_pypi:
-        description: 'Publish to test PyPI'
+        description: "Publish to test PyPI"
         required: false
         default: false
         type: boolean
       publish_to_pypi:
-        description: 'Publish to PyPI'
+        description: "Publish to PyPI"
         required: false
         default: false
         type: boolean
       version:
-        description: 'Version to publish'
+        description: "Version to publish"
         required: false
         type: string
 
   workflow_call:
     inputs:
       publish_to_test_pypi:
-        description: 'Publish to test PyPI'
+        description: "Publish to test PyPI"
         required: false
         default: false
         type: boolean
       publish_to_pypi:
-        description: 'Publish to PyPI'
+        description: "Publish to PyPI"
         required: false
         default: false
         type: boolean
       version:
-        description: 'Version to publish'
+        description: "Version to publish"
         required: false
         type: string
 
@@ -72,8 +72,8 @@ jobs:
               target: aarch64,
             }
           - { os: windows, runner: blacksmith-8vcpu-windows-2025, target: x64 }
-          - { os: macos, runner: macos-14, target: x86_64 }
-          - { os: macos, runner: macos-14, target: aarch64 }
+          # - { os: macos, runner: macos-14, target: x86_64 }
+          # - { os: macos, runner: macos-14, target: aarch64 }
 
     steps:
       - uses: actions/checkout@v4
@@ -119,84 +119,84 @@ jobs:
           name: wheels-${{ matrix.platform.os }}-${{ matrix.platform.target }}
           path: dist
 
-  sdist:
-    name: build-sdist
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: version
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Rust
-        uses: ./.github/actions/rust
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set version in pyproject.toml
-        shell: bash
-        run: |
-          pip install toml
-          python -c "
-          import os
-          import toml
+  # sdist:
+  #   name: build-sdist
+  #   runs-on: blacksmith-4vcpu-ubuntu-2404
+  #   needs: version
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Setup Rust
+  #       uses: ./.github/actions/rust
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Set version in pyproject.toml
+  #       shell: bash
+  #       run: |
+  #         pip install toml
+  #         python -c "
+  #         import os
+  #         import toml
 
-          file_path = 'pyproject.toml'
-          data = toml.load(file_path)
+  #         file_path = 'pyproject.toml'
+  #         data = toml.load(file_path)
 
-          # Set the package version
-          data['project']['version'] = '${{ needs.version.outputs.version }}'
-          data['project']['dynamic'] = []
+  #         # Set the package version
+  #         data['project']['version'] = '${{ needs.version.outputs.version }}'
+  #         data['project']['dynamic'] = []
 
-          with open(file_path, 'w') as f:
-              toml.dump(data, f)
-          "
-      - name: Build sdist
-        uses: PyO3/maturin-action@v1
-        with:
-          command: sdist
-          args: --out dist
-      - name: Test sdist
-        run: |
-          pip install dist/*.tar.gz
-          python -c "import chromadb; api = chromadb.Client(); print(api.heartbeat())"
-      - name: Upload sdist
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-sdist
-          path: dist
+  #         with open(file_path, 'w') as f:
+  #             toml.dump(data, f)
+  #         "
+  #     - name: Build sdist
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         command: sdist
+  #         args: --out dist
+  #     - name: Test sdist
+  #       run: |
+  #         pip install dist/*.tar.gz
+  #         python -c "import chromadb; api = chromadb.Client(); print(api.heartbeat())"
+  #     - name: Upload sdist
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: wheels-sdist
+  #         path: dist
 
-  release:
-    name: Release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: ${{ inputs.publish_to_pypi || inputs.publish_to_test_pypi }}
-    needs: [build, sdist]
-    permissions:
-      # Use to sign the release artifacts
-      id-token: write
-      # Used to upload release artifacts
-      contents: write
-      # Used to generate artifact attestation
-      attestations: write
-    steps:
-      - uses: actions/download-artifact@v4
+  # release:
+  #   name: Release
+  #   runs-on: blacksmith-4vcpu-ubuntu-2404
+  #   if: ${{ inputs.publish_to_pypi || inputs.publish_to_test_pypi }}
+  #   needs: [build, sdist]
+  #   permissions:
+  #     # Use to sign the release artifacts
+  #     id-token: write
+  #     # Used to upload release artifacts
+  #     contents: write
+  #     # Used to generate artifact attestation
+  #     attestations: write
+  #   steps:
+  #     - uses: actions/download-artifact@v4
 
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: 'wheels-*/*'
+  #     - name: Generate artifact attestation
+  #       uses: actions/attest-build-provenance@v1
+  #       with:
+  #         subject-path: "wheels-*/*"
 
-      - name: Publish to test PyPI
-        if: ${{ inputs.publish_to_test_pypi }}
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          MATURIN_REPOSITORY_URL: https://test.pypi.org/legacy/
-        with:
-          command: upload
-          args: --non-interactive wheels-*/*
+  #     - name: Publish to test PyPI
+  #       if: ${{ inputs.publish_to_test_pypi }}
+  #       uses: PyO3/maturin-action@v1
+  #       env:
+  #         MATURIN_PYPI_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+  #         MATURIN_REPOSITORY_URL: https://test.pypi.org/legacy/
+  #       with:
+  #         command: upload
+  #         args: --non-interactive wheels-*/*
 
-      - name: Publish to PyPI
-        if: ${{ inputs.publish_to_pypi }}
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        with:
-          command: upload
-          args: --non-interactive wheels-*/*
+  #     - name: Publish to PyPI
+  #       if: ${{ inputs.publish_to_pypi }}
+  #       uses: PyO3/maturin-action@v1
+  #       env:
+  #         MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+  #       with:
+  #         command: upload
+  #         args: --non-interactive wheels-*/*

--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -13,10 +13,9 @@ on:
         required: false
         default: false
         type: boolean
-      version:
-        description: "Version to publish"
-        required: false
-        type: string
+  schedule:
+    # Run every hour for testing Windows runners
+    - cron: '0 * * * *'
 
   workflow_call:
     inputs:

--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -58,7 +58,7 @@ jobs:
             echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
           fi
   build:
-    name: build-${{ matrix.platform.os }}-${{ matrix.platform.target }}
+    name: build-${{ matrix.platform.os }}-${{ matrix.platform.target }}-${{ matrix.platform.runner_type || 'default' }}
     runs-on: ${{ matrix.platform.runner }}
     needs: version
     strategy:
@@ -71,7 +71,18 @@ jobs:
               runner: blacksmith-4vcpu-ubuntu-2404-arm,
               target: aarch64,
             }
-          - { os: windows, runner: blacksmith-8vcpu-windows-2025, target: x64 }
+          - {
+              os: windows,
+              runner: [blacksmith-staging-4vcpu-windows-2025, bs-dev-taha],
+              target: x64,
+              runner_type: blacksmith,
+            }
+          - {
+              os: windows,
+              runner: windows-2025,
+              target: x64,
+              runner_type: github,
+            }
           # - { os: macos, runner: macos-14, target: x86_64 }
           # - { os: macos, runner: macos-14, target: aarch64 }
 
@@ -116,7 +127,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.platform.os }}-${{ matrix.platform.target }}
+          name: wheels-${{ matrix.platform.os }}-${{ matrix.platform.target }}-${{ matrix.platform.runner_type || 'default' }}
           path: dist
 
   # sdist:

--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -15,7 +15,7 @@ on:
         type: boolean
   schedule:
     # Run every hour for testing Windows runners
-    - cron: '0 * * * *'
+    - cron: "0 * * * *"
 
   workflow_call:
     inputs:
@@ -64,12 +64,12 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { os: linux, runner: blacksmith-4vcpu-ubuntu-2404, target: x86_64 }
-          - {
-              os: linux,
-              runner: blacksmith-4vcpu-ubuntu-2404-arm,
-              target: aarch64,
-            }
+          # - { os: linux, runner: blacksmith-4vcpu-ubuntu-2404, target: x86_64 }
+          # - {
+          #     os: linux,
+          #     runner: blacksmith-4vcpu-ubuntu-2404-arm,
+          #     target: aarch64,
+          #   }
           - {
               os: windows,
               runner: blacksmith-staging-8vcpu-windows-2025,

--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -14,8 +14,8 @@ on:
         default: false
         type: boolean
   schedule:
-    # Run every hour for testing Windows runners
-    - cron: "0 * * * *"
+    # TEMPORARY: Run every 30 minutes for benchmarking/testing Blacksmith Windows runners
+    - cron: "*/30 * * * *"
 
   workflow_call:
     inputs:

--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -73,13 +73,13 @@ jobs:
             }
           - {
               os: windows,
-              runner: [blacksmith-staging-4vcpu-windows-2025, bs-dev-taha],
+              runner: blacksmith-staging-8vcpu-windows-2025,
               target: x64,
               runner_type: blacksmith,
             }
           - {
               os: windows,
-              runner: windows-2025,
+              runner: 8core-32gb-windows-2025,
               target: x64,
               runner_type: github,
             }

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -263,7 +263,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
-    runs-on: 8core-32gb-windows-latest
+    runs-on: blacksmith-8vcpu-windows-2025
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -4,18 +4,18 @@ on:
   workflow_call:
     inputs:
       python_versions:
-        description: 'Python versions to test (as json array)'
+        description: "Python versions to test (as json array)"
         required: false
         default: '["3.9"]'
         type: string
       property_testing_preset:
-        description: 'Property testing preset'
+        description: "Property testing preset"
         required: true
         type: string
       runner:
-        description: 'Runner to test on (string)'
+        description: "Runner to test on (string)"
         required: false
-        default: 'blacksmith-8vcpu-ubuntu-2404'
+        default: "blacksmith-8vcpu-ubuntu-2404"
         type: string
 
 jobs:
@@ -31,7 +31,7 @@ jobs:
           - "chromadb/test/property/test_cross_version_persist.py"
         include:
           - test-glob: "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
-            parallelized: false  # Disabled to fix INTERNALERROR crashes in CI
+            parallelized: false # Disabled to fix INTERNALERROR crashes in CI
 
     runs-on: ${{ inputs.runner }}
     steps:
@@ -76,20 +76,20 @@ jobs:
           - "chromadb/test/stress"
     runs-on: ${{ inputs.runner }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Setup Python (${{ matrix.python }})
-      uses: ./.github/actions/python
-    - name: Setup Rust
-      uses: ./.github/actions/rust
-      with:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python (${{ matrix.python }})
+        uses: ./.github/actions/python
+      - name: Setup Rust
+        uses: ./.github/actions/rust
+        with:
           github-token: ${{ github.token }}
-    - name: Rust Integration Test
-      run: bin/rust-integration-test.sh ${{ matrix.test-glob }}
-      shell: bash
-      env:
-        ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
-        PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+      - name: Rust Integration Test
+        run: bin/rust-integration-test.sh ${{ matrix.test-glob }}
+        shell: bash
+        env:
+          ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
+          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
   test-rust-thin-client:
     strategy:
@@ -232,27 +232,27 @@ jobs:
         python: ${{ fromJson(inputs.python_versions) }}
     runs-on: ${{ inputs.runner }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Setup Python (${{ matrix.python }})
-      uses: ./.github/actions/python
-    - name: Setup Rust
-      uses: ./.github/actions/rust
-      with:
-        github-token: ${{ github.token }}
-    - name: Build Rust bindings
-      uses: PyO3/maturin-action@v1
-      with:
-        command: build
-    - name: Install built wheel
-      shell: bash
-      run: pip install --no-index --find-links target/wheels/ chromadb
-    - name: Integration Test
-      run: python -m pytest "chromadb/test/test_cli.py"
-      shell: bash
-      env:
-        ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
-        PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python (${{ matrix.python }})
+        uses: ./.github/actions/python
+      - name: Setup Rust
+        uses: ./.github/actions/rust
+        with:
+          github-token: ${{ github.token }}
+      - name: Build Rust bindings
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+      - name: Install built wheel
+        shell: bash
+        run: pip install --no-index --find-links target/wheels/ chromadb
+      - name: Integration Test
+        run: python -m pytest "chromadb/test/test_cli.py"
+        shell: bash
+        env:
+          ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
+          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
   test-windows-smoke:
     # only run windows smoke tests when the runner isn't already windows,

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -296,10 +296,9 @@ jobs:
           Write-Host "Current PATH: $currentPath"
 
           $newPath = $msvcBinPath + ';' + $currentPath
-          Write-Host "New PATH: $newPath"
-
           [Environment]::SetEnvironmentVariable("PATH", $newPath, "Machine")
-          Write-Host "Final PATH: [System.Environment]::GetEnvironmentVariable("PATH", "Machine")"
+          $finalPath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
+          Write-Host "New PATH: $finalPath"
         shell: powershell
 
       - name: Build Rust bindings

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -264,9 +264,8 @@ jobs:
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
     runs-on:
-      # - blacksmith-staging-8vcpu-windows-2025
-      # - bs-dev-taha
-      - windows-2025
+      - blacksmith-staging-8vcpu-windows-2025
+      - bs-dev-taha
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -263,7 +263,9 @@ jobs:
       fail-fast: false
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
-    runs-on: blacksmith-staging-8vcpu-windows-2025
+    runs-on:
+      - blacksmith-staging-8vcpu-windows-2025
+      - bs-dev-taha
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -259,13 +259,15 @@ jobs:
     # also only run the smoke tests on PRs (ie not main and not tags) since
     # we are already running the full suite on Windows in those cases
     if: ${{ !contains(inputs.runner, 'windows') && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+    name: Windows Smoke Test (${{ matrix.runner }} - Python ${{ matrix.python }})
     strategy:
       fail-fast: false
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
-    runs-on:
-      - blacksmith-staging-8vcpu-windows-2025
-      - bs-dev-taha
+        runner:
+          - [blacksmith-staging-4vcpu-windows-2025, bs-dev-taha]
+          - windows-2025
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -280,28 +280,28 @@ jobs:
 
       # TEMPORARY STEP TO INSTALL MSVC TOOLS
       # BEFORE RELEASING A NEW WINDOWS RUNNER
-      - name: Install dependencies
-        run: |
-          choco install visualstudio2022buildtools -y --no-progress
-          choco install visualstudio2022-workload-vctools -y --no-progress
+      # - name: Install dependencies
+      #   run: |
+      #     choco install visualstudio2022buildtools -y --no-progress
+      #     choco install visualstudio2022-workload-vctools -y --no-progress
 
-          Write-Host "Setting VS2022_BUILDTOOLS environment variable"
-          [Environment]::SetEnvironmentVariable("VS2022_BUILDTOOLS", 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools', [System.EnvironmentVariableTarget]::Machine)
+      #     Write-Host "Setting VS2022_BUILDTOOLS environment variable"
+      #     [Environment]::SetEnvironmentVariable("VS2022_BUILDTOOLS", 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools', [System.EnvironmentVariableTarget]::Machine)
 
-          $msvcPath = Get-ChildItem -Path "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC" -Directory | Select-Object -First 1
-          Write-Output "MSVC path: $msvcPath"
+      #     $msvcPath = Get-ChildItem -Path "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC" -Directory | Select-Object -First 1
+      #     Write-Output "MSVC path: $msvcPath"
 
-          $msvcBinPath = Join-Path $msvcPath.FullName "bin\Hostx64\x64"
-          Write-Host "Adding MSVC tools to PATH: $msvcBinPath"
+      #     $msvcBinPath = Join-Path $msvcPath.FullName "bin\Hostx64\x64"
+      #     Write-Host "Adding MSVC tools to PATH: $msvcBinPath"
 
-          $currentPath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
-          Write-Host "Current PATH: $currentPath"
+      #     $currentPath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
+      #     Write-Host "Current PATH: $currentPath"
 
-          $newPath = $msvcBinPath + ';' + $currentPath
-          [Environment]::SetEnvironmentVariable("PATH", $newPath, "Machine")
-          $finalPath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
-          Write-Host "New PATH: $finalPath"
-        shell: powershell
+      #     $newPath = $msvcBinPath + ';' + $currentPath
+      #     [Environment]::SetEnvironmentVariable("PATH", $newPath, "Machine")
+      #     $finalPath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
+      #     Write-Host "New PATH: $finalPath"
+      #   shell: powershell
 
       - name: Build Rust bindings
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -263,7 +263,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
-    runs-on: blacksmith-8vcpu-windows-2025
+    runs-on: blacksmith-staging-8vcpu-windows-2025
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -275,6 +275,33 @@ jobs:
         uses: ./.github/actions/rust
         with:
           github-token: ${{ github.token }}
+
+      # TEMPORARY STEP TO INSTALL MSVC TOOLS
+      # BEFORE RELEASING A NEW WINDOWS RUNNER
+      - name: Install dependencies
+        run: |
+          choco install visualstudio2022buildtools -y --no-progress
+          choco install visualstudio2022-workload-vctools -y --no-progress
+
+          Write-Host "Setting VS2022_BUILDTOOLS environment variable"
+          [Environment]::SetEnvironmentVariable("VS2022_BUILDTOOLS", 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools', [System.EnvironmentVariableTarget]::Machine)
+
+          $msvcPath = Get-ChildItem -Path "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC" -Directory | Select-Object -First 1
+          Write-Output "MSVC path: $msvcPath"
+
+          $msvcBinPath = Join-Path $msvcPath.FullName "bin\Hostx64\x64"
+          Write-Host "Adding MSVC tools to PATH: $msvcBinPath"
+
+          $currentPath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
+          Write-Host "Current PATH: $currentPath"
+
+          $newPath = $msvcBinPath + ';' + $currentPath
+          Write-Host "New PATH: $newPath"
+
+          [Environment]::SetEnvironmentVariable("PATH", $newPath, "Machine")
+          Write-Host "Final PATH: [System.Environment]::GetEnvironmentVariable("PATH", "Machine")"
+        shell: powershell
+
       - name: Build Rust bindings
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -19,240 +19,240 @@ on:
         type: string
 
 jobs:
-  test-rust-bindings:
-    timeout-minutes: 90
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ${{ fromJson(inputs.python_versions) }}
-        test-glob:
-          - "--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*'"
-          - "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
-          - "chromadb/test/property/test_cross_version_persist.py"
-        include:
-          - test-glob: "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
-            parallelized: false # Disabled to fix INTERNALERROR crashes in CI
+  # test-rust-bindings:
+  #   timeout-minutes: 90
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python: ${{ fromJson(inputs.python_versions) }}
+  #       test-glob:
+  #         - "--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*'"
+  #         - "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
+  #         - "chromadb/test/property/test_cross_version_persist.py"
+  #       include:
+  #         - test-glob: "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
+  #           parallelized: false # Disabled to fix INTERNALERROR crashes in CI
 
-    runs-on: ${{ inputs.runner }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Python
-        uses: ./.github/actions/python
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Setup Rust
-        uses: ./.github/actions/rust
-        with:
-          github-token: ${{ github.token }}
-      - name: Build Rust bindings
-        uses: PyO3/maturin-action@v1
-        with:
-          command: build
-      - name: Install built wheel
-        shell: bash
-        run: pip install --no-index --find-links target/wheels/ chromadb
-      - name: Test
-        run: python -m pytest ${{ matrix.test-glob }} ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} -v --color=yes --durations 10
-        shell: bash
-        env:
-          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
-          CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
-          RUST_BACKTRACE: 1
+  #   runs-on: ${{ inputs.runner }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Setup Python
+  #       uses: ./.github/actions/python
+  #       with:
+  #         python-version: ${{ matrix.python }}
+  #     - name: Setup Rust
+  #       uses: ./.github/actions/rust
+  #       with:
+  #         github-token: ${{ github.token }}
+  #     - name: Build Rust bindings
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         command: build
+  #     - name: Install built wheel
+  #       shell: bash
+  #       run: pip install --no-index --find-links target/wheels/ chromadb
+  #     - name: Test
+  #       run: python -m pytest ${{ matrix.test-glob }} ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} -v --color=yes --durations 10
+  #       shell: bash
+  #       env:
+  #         PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+  #         CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
+  #         RUST_BACKTRACE: 1
 
-  test-rust-single-node-integration:
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ${{ fromJson(inputs.python_versions) }}
-        test-glob:
-          - "--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore='chromadb/test/test_cli.py' --ignore-glob 'chromadb/test/distributed/*'"
-          - "chromadb/test/property/test_add.py"
-          - "chromadb/test/property/test_collections.py"
-          - "chromadb/test/property/test_collections_with_database_tenant.py"
-          - "chromadb/test/property/test_cross_version_persist.py"
-          - "chromadb/test/property/test_embeddings.py"
-          - "chromadb/test/property/test_filtering.py"
-          - "chromadb/test/property/test_persist.py"
-          - "chromadb/test/stress"
-    runs-on: ${{ inputs.runner }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Python (${{ matrix.python }})
-        uses: ./.github/actions/python
-      - name: Setup Rust
-        uses: ./.github/actions/rust
-        with:
-          github-token: ${{ github.token }}
-      - name: Rust Integration Test
-        run: bin/rust-integration-test.sh ${{ matrix.test-glob }}
-        shell: bash
-        env:
-          ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
-          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+  # test-rust-single-node-integration:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python: ${{ fromJson(inputs.python_versions) }}
+  #       test-glob:
+  #         - "--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore='chromadb/test/test_cli.py' --ignore-glob 'chromadb/test/distributed/*'"
+  #         - "chromadb/test/property/test_add.py"
+  #         - "chromadb/test/property/test_collections.py"
+  #         - "chromadb/test/property/test_collections_with_database_tenant.py"
+  #         - "chromadb/test/property/test_cross_version_persist.py"
+  #         - "chromadb/test/property/test_embeddings.py"
+  #         - "chromadb/test/property/test_filtering.py"
+  #         - "chromadb/test/property/test_persist.py"
+  #         - "chromadb/test/stress"
+  #   runs-on: ${{ inputs.runner }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Setup Python (${{ matrix.python }})
+  #       uses: ./.github/actions/python
+  #     - name: Setup Rust
+  #       uses: ./.github/actions/rust
+  #       with:
+  #         github-token: ${{ github.token }}
+  #     - name: Rust Integration Test
+  #       run: bin/rust-integration-test.sh ${{ matrix.test-glob }}
+  #       shell: bash
+  #       env:
+  #         ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
+  #         PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
-  test-rust-thin-client:
-    strategy:
-      matrix:
-        python: ${{ fromJson(inputs.python_versions) }}
-        test-glob:
-          - "chromadb/test/property/test_add.py"
-          - "chromadb/test/property/test_collections.py"
-          - "chromadb/test/property/test_collections_with_database_tenant.py"
-          - "chromadb/test/property/test_embeddings.py"
-          - "chromadb/test/property/test_filtering.py"
-    runs-on: ${{ inputs.runner }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Python (${{ matrix.python }})
-        uses: ./.github/actions/python
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Setup Rust
-        uses: ./.github/actions/rust
-        with:
-          github-token: ${{ github.token }}
-      - name: Test
-        run: bin/rust-integration-test.sh ${{ matrix.test-glob }}
-        shell: bash
-        env:
-          CHROMA_THIN_CLIENT: "1"
-          ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
-          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+  # test-rust-thin-client:
+  #   strategy:
+  #     matrix:
+  #       python: ${{ fromJson(inputs.python_versions) }}
+  #       test-glob:
+  #         - "chromadb/test/property/test_add.py"
+  #         - "chromadb/test/property/test_collections.py"
+  #         - "chromadb/test/property/test_collections_with_database_tenant.py"
+  #         - "chromadb/test/property/test_embeddings.py"
+  #         - "chromadb/test/property/test_filtering.py"
+  #   runs-on: ${{ inputs.runner }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Setup Python (${{ matrix.python }})
+  #       uses: ./.github/actions/python
+  #       with:
+  #         python-version: ${{ matrix.python }}
+  #     - name: Setup Rust
+  #       uses: ./.github/actions/rust
+  #       with:
+  #         github-token: ${{ github.token }}
+  #     - name: Test
+  #       run: bin/rust-integration-test.sh ${{ matrix.test-glob }}
+  #       shell: bash
+  #       env:
+  #         CHROMA_THIN_CLIENT: "1"
+  #         ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
+  #         PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
-  test-cluster-rust-frontend:
-    if: ${{ contains(inputs.runner, 'ubuntu') }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ${{ fromJson(inputs.python_versions) }}
-        test-glob:
-          - "chromadb/test/api"
-          - "chromadb/test/api/test_collection.py"
-          - "chromadb/test/api/test_limit_offset.py"
-          - "chromadb/test/property/test_collections.py"
-          - "chromadb/test/property/test_add.py"
-          - "chromadb/test/property/test_filtering.py"
-          - "chromadb/test/property/test_fork.py"
-          - "chromadb/test/property/test_embeddings.py"
-          - "chromadb/test/property/test_collections_with_database_tenant.py"
-          - "chromadb/test/property/test_collections_with_database_tenant_overwrite.py"
-          - "chromadb/test/distributed/test_sanity.py"
-          - "chromadb/test/distributed/test_log_backpressure.py"
-          - "chromadb/test/distributed/test_repair_collection_log_offset.py"
-        include:
-          - test-glob: "chromadb/test/property/test_add.py"
-            parallelized: false
-          - test-glob: "chromadb/test/property/test_embeddings.py"
-            parallelized: true
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    # OIDC token auth for AWS
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Python (${{ matrix.python }})
-        uses: ./.github/actions/python
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Setup Docker
-        uses: ./.github/actions/docker
-        with:
-          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-          dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Start Tilt services
-        uses: ./.github/actions/tilt
-      - name: Test
-        run: bin/cluster-test.sh bash -c 'python -m pytest "${{ matrix.test-glob }}" ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} --durations 10'
-        shell: bash
-        env:
-          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
-          CHROMA_RUST_FRONTEND_TEST_ONLY: "1"
-          CHROMA_SERVER_HOST: "localhost:8000"
-      - name: Compute artifact name
-        if: always()
-        id: compute-artifact-name
-        run: echo "artifact_name=cluster_logs_rust_frontend_$(basename "${{ matrix.test-glob }}" .py)_${{ matrix.python }}" >> $GITHUB_OUTPUT
-      - name: Save service logs to artifact
-        if: always()
-        uses: ./.github/actions/export-tilt-logs
-        with:
-          artifact-name: ${{ steps.compute-artifact-name.outputs.artifact_name }}
+  # test-cluster-rust-frontend:
+  #   if: ${{ contains(inputs.runner, 'ubuntu') }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python: ${{ fromJson(inputs.python_versions) }}
+  #       test-glob:
+  #         - "chromadb/test/api"
+  #         - "chromadb/test/api/test_collection.py"
+  #         - "chromadb/test/api/test_limit_offset.py"
+  #         - "chromadb/test/property/test_collections.py"
+  #         - "chromadb/test/property/test_add.py"
+  #         - "chromadb/test/property/test_filtering.py"
+  #         - "chromadb/test/property/test_fork.py"
+  #         - "chromadb/test/property/test_embeddings.py"
+  #         - "chromadb/test/property/test_collections_with_database_tenant.py"
+  #         - "chromadb/test/property/test_collections_with_database_tenant_overwrite.py"
+  #         - "chromadb/test/distributed/test_sanity.py"
+  #         - "chromadb/test/distributed/test_log_backpressure.py"
+  #         - "chromadb/test/distributed/test_repair_collection_log_offset.py"
+  #       include:
+  #         - test-glob: "chromadb/test/property/test_add.py"
+  #           parallelized: false
+  #         - test-glob: "chromadb/test/property/test_embeddings.py"
+  #           parallelized: true
+  #   runs-on: blacksmith-8vcpu-ubuntu-2404
+  #   # OIDC token auth for AWS
+  #   permissions:
+  #     contents: read
+  #     id-token: write
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Setup Python (${{ matrix.python }})
+  #       uses: ./.github/actions/python
+  #       with:
+  #         python-version: ${{ matrix.python }}
+  #     - name: Setup Docker
+  #       uses: ./.github/actions/docker
+  #       with:
+  #         dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+  #     - name: Start Tilt services
+  #       uses: ./.github/actions/tilt
+  #     - name: Test
+  #       run: bin/cluster-test.sh bash -c 'python -m pytest "${{ matrix.test-glob }}" ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} --durations 10'
+  #       shell: bash
+  #       env:
+  #         PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+  #         CHROMA_RUST_FRONTEND_TEST_ONLY: "1"
+  #         CHROMA_SERVER_HOST: "localhost:8000"
+  #     - name: Compute artifact name
+  #       if: always()
+  #       id: compute-artifact-name
+  #       run: echo "artifact_name=cluster_logs_rust_frontend_$(basename "${{ matrix.test-glob }}" .py)_${{ matrix.python }}" >> $GITHUB_OUTPUT
+  #     - name: Save service logs to artifact
+  #       if: always()
+  #       uses: ./.github/actions/export-tilt-logs
+  #       with:
+  #         artifact-name: ${{ steps.compute-artifact-name.outputs.artifact_name }}
 
-  merge-cluster-logs:
-    if: ${{ contains(inputs.runner, 'ubuntu') }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: test-cluster-rust-frontend
-    steps:
-      - name: Merge
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: cluster_test_logs
-          pattern: cluster_logs_*
+  # merge-cluster-logs:
+  #   if: ${{ contains(inputs.runner, 'ubuntu') }}
+  #   runs-on: blacksmith-4vcpu-ubuntu-2404
+  #   needs: test-cluster-rust-frontend
+  #   steps:
+  #     - name: Merge
+  #       uses: actions/upload-artifact/merge@v4
+  #       with:
+  #         name: cluster_test_logs
+  #         pattern: cluster_logs_*
 
-  test-rust-bindings-stress:
-    timeout-minutes: 90
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ${{ fromJson(inputs.python_versions) }}
-    runs-on: ${{ inputs.runner }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Python (${{ matrix.python }})
-        uses: ./.github/actions/python
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Setup Rust
-        uses: ./.github/actions/rust
-        with:
-          github-token: ${{ github.token }}
-      - name: Build Rust bindings
-        uses: PyO3/maturin-action@v1
-        with:
-          command: build
-      - name: Install built wheel
-        shell: bash
-        run: pip install --no-index --find-links target/wheels/ chromadb
-      - name: Test
-        run: python -m pytest chromadb/test/stress --durations 10
-        shell: bash
-        env:
-          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
-          CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
+  # test-rust-bindings-stress:
+  #   timeout-minutes: 90
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python: ${{ fromJson(inputs.python_versions) }}
+  #   runs-on: ${{ inputs.runner }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Setup Python (${{ matrix.python }})
+  #       uses: ./.github/actions/python
+  #       with:
+  #         python-version: ${{ matrix.python }}
+  #     - name: Setup Rust
+  #       uses: ./.github/actions/rust
+  #       with:
+  #         github-token: ${{ github.token }}
+  #     - name: Build Rust bindings
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         command: build
+  #     - name: Install built wheel
+  #       shell: bash
+  #       run: pip install --no-index --find-links target/wheels/ chromadb
+  #     - name: Test
+  #       run: python -m pytest chromadb/test/stress --durations 10
+  #       shell: bash
+  #       env:
+  #         PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+  #         CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
 
-  test-python-cli:
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ${{ fromJson(inputs.python_versions) }}
-    runs-on: ${{ inputs.runner }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Python (${{ matrix.python }})
-        uses: ./.github/actions/python
-      - name: Setup Rust
-        uses: ./.github/actions/rust
-        with:
-          github-token: ${{ github.token }}
-      - name: Build Rust bindings
-        uses: PyO3/maturin-action@v1
-        with:
-          command: build
-      - name: Install built wheel
-        shell: bash
-        run: pip install --no-index --find-links target/wheels/ chromadb
-      - name: Integration Test
-        run: python -m pytest "chromadb/test/test_cli.py"
-        shell: bash
-        env:
-          ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
-          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+  # test-python-cli:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python: ${{ fromJson(inputs.python_versions) }}
+  #   runs-on: ${{ inputs.runner }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Setup Python (${{ matrix.python }})
+  #       uses: ./.github/actions/python
+  #     - name: Setup Rust
+  #       uses: ./.github/actions/rust
+  #       with:
+  #         github-token: ${{ github.token }}
+  #     - name: Build Rust bindings
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         command: build
+  #     - name: Install built wheel
+  #       shell: bash
+  #       run: pip install --no-index --find-links target/wheels/ chromadb
+  #     - name: Integration Test
+  #       run: python -m pytest "chromadb/test/test_cli.py"
+  #       shell: bash
+  #       env:
+  #         ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
+  #         PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
   test-windows-smoke:
     # only run windows smoke tests when the runner isn't already windows,

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -265,8 +265,8 @@ jobs:
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
         runner:
-          - [blacksmith-staging-4vcpu-windows-2025, bs-dev-taha]
-          - windows-2025
+          - blacksmith-staging-8vcpu-windows-2025
+          - 8core-32gb-windows-2025
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
@@ -279,32 +279,6 @@ jobs:
         uses: ./.github/actions/rust
         with:
           github-token: ${{ github.token }}
-
-      # TEMPORARY STEP TO INSTALL MSVC TOOLS
-      # BEFORE RELEASING A NEW WINDOWS RUNNER
-      # - name: Install dependencies
-      #   run: |
-      #     choco install visualstudio2022buildtools -y --no-progress
-      #     choco install visualstudio2022-workload-vctools -y --no-progress
-
-      #     Write-Host "Setting VS2022_BUILDTOOLS environment variable"
-      #     [Environment]::SetEnvironmentVariable("VS2022_BUILDTOOLS", 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools', [System.EnvironmentVariableTarget]::Machine)
-
-      #     $msvcPath = Get-ChildItem -Path "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC" -Directory | Select-Object -First 1
-      #     Write-Output "MSVC path: $msvcPath"
-
-      #     $msvcBinPath = Join-Path $msvcPath.FullName "bin\Hostx64\x64"
-      #     Write-Host "Adding MSVC tools to PATH: $msvcBinPath"
-
-      #     $currentPath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
-      #     Write-Host "Current PATH: $currentPath"
-
-      #     $newPath = $msvcBinPath + ';' + $currentPath
-      #     [Environment]::SetEnvironmentVariable("PATH", $newPath, "Machine")
-      #     $finalPath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
-      #     Write-Host "New PATH: $finalPath"
-      #   shell: powershell
-
       - name: Build Rust bindings
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -264,8 +264,9 @@ jobs:
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
     runs-on:
-      - blacksmith-staging-8vcpu-windows-2025
-      - bs-dev-taha
+      # - blacksmith-staging-8vcpu-windows-2025
+      # - bs-dev-taha
+      - windows-2025
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
       - "**"
+  schedule:
+    # TEMPORARY: Run every 30 minutes for benchmarking/testing Blacksmith Windows runners
+    - cron: "*/30 * * * *"
 
 jobs:
   # This job detects what changed and determines which tests to run

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,240 +3,240 @@ on:
   pull_request:
     branches:
       - main
-      - '**'
+      - "**"
 
 jobs:
   # This job detects what changed and determines which tests to run
-  change-detection:
-    name: Detect changes and determine tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    outputs:
-      # Component changes
-      docs-only: ${{ steps.determine-tests.outputs.docs-only }}
-      helm-changes: ${{ steps.filter.outputs.helm-changes }}
-      # Test flags as a JSON array
-      tests-to-run: ${{ steps.determine-tests.outputs.tests-to-run }}
-      # Helm version check
-      helm-version-changed: ${{ steps.helm-version.outputs.version_changed }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
+  # change-detection:
+  #   name: Detect changes and determine tests
+  #   runs-on: blacksmith-4vcpu-ubuntu-2404
+  #   outputs:
+  #     # Component changes
+  #     docs-only: ${{ steps.determine-tests.outputs.docs-only }}
+  #     helm-changes: ${{ steps.filter.outputs.helm-changes }}
+  #     # Test flags as a JSON array
+  #     tests-to-run: ${{ steps.determine-tests.outputs.tests-to-run }}
+  #     # Helm version check
+  #     helm-version-changed: ${{ steps.helm-version.outputs.version_changed }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 2
 
-      - name: Filter changes
-        id: filter
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            # documentation changes
-            docs:
-              - 'docs/**'
-            # Outside docs
-            outside-docs:
-              - '!docs/**'
-              - '!**/*.md'
-            # Helm chart changes
-            helm-changes:
-              - 'k8s/distributed-chroma/**'
-            # JavaScript client changes
-            js-client:
-              - 'clients/js/**'
-            # Outside JS client
-            outside-js-client:
-              - '!clients/js/**'
+  #     - name: Filter changes
+  #       id: filter
+  #       uses: dorny/paths-filter@v3
+  #       with:
+  #         filters: |
+  #           # documentation changes
+  #           docs:
+  #             - 'docs/**'
+  #           # Outside docs
+  #           outside-docs:
+  #             - '!docs/**'
+  #             - '!**/*.md'
+  #           # Helm chart changes
+  #           helm-changes:
+  #             - 'k8s/distributed-chroma/**'
+  #           # JavaScript client changes
+  #           js-client:
+  #             - 'clients/js/**'
+  #           # Outside JS client
+  #           outside-js-client:
+  #             - '!clients/js/**'
 
-      - name: Determine tests to run
-        id: determine-tests
-        run: |
-          # Initialize an empty array
-          TESTS_TO_RUN="[]"
+  #     - name: Determine tests to run
+  #       id: determine-tests
+  #       run: |
+  #         # Initialize an empty array
+  #         TESTS_TO_RUN="[]"
 
-          # If changes are docs-only (changes in docs but not outside docs)
-          if [[ "${{ steps.filter.outputs.docs }}" == "true" && "${{ steps.filter.outputs.outside-docs }}" == "false" ]]; then
-            echo "Only documentation changes detected, skipping all tests"
-            echo "docs-only=true" >> $GITHUB_OUTPUT
-            echo "tests-to-run=${TESTS_TO_RUN}" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "docs-only=false" >> $GITHUB_OUTPUT
-          fi
+  #         # If changes are docs-only (changes in docs but not outside docs)
+  #         if [[ "${{ steps.filter.outputs.docs }}" == "true" && "${{ steps.filter.outputs.outside-docs }}" == "false" ]]; then
+  #           echo "Only documentation changes detected, skipping all tests"
+  #           echo "docs-only=true" >> $GITHUB_OUTPUT
+  #           echo "tests-to-run=${TESTS_TO_RUN}" >> $GITHUB_OUTPUT
+  #           exit 0
+  #         else
+  #           echo "docs-only=false" >> $GITHUB_OUTPUT
+  #         fi
 
-          # Check for JS-only changes (changes in JS but not outside JS)
-          if [[ "${{ steps.filter.outputs.js-client }}" == "true" && "${{ steps.filter.outputs.outside-js-client }}" == "false" ]]; then
-            echo "JavaScript-only changes detected"
-            TESTS_TO_RUN='["js-client"]'
-            echo "tests-to-run=${TESTS_TO_RUN}" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+  #         # Check for JS-only changes (changes in JS but not outside JS)
+  #         if [[ "${{ steps.filter.outputs.js-client }}" == "true" && "${{ steps.filter.outputs.outside-js-client }}" == "false" ]]; then
+  #           echo "JavaScript-only changes detected"
+  #           TESTS_TO_RUN='["js-client"]'
+  #           echo "tests-to-run=${TESTS_TO_RUN}" >> $GITHUB_OUTPUT
+  #           exit 0
+  #         fi
 
-          # If we get here, we need to run all tests (core changes)
-          echo "Core changes detected, running all tests"
-          TESTS_TO_RUN='["python", "rust", "js-client", "go"]'
-          echo "tests-to-run=${TESTS_TO_RUN}" >> $GITHUB_OUTPUT
+  #         # If we get here, we need to run all tests (core changes)
+  #         echo "Core changes detected, running all tests"
+  #         TESTS_TO_RUN='["python", "rust", "js-client", "go"]'
+  #         echo "tests-to-run=${TESTS_TO_RUN}" >> $GITHUB_OUTPUT
 
-      - name: Check Helm version change
-        id: helm-version
-        if: steps.filter.outputs.helm-changes == 'true'
-        shell: bash
-        run: |
-          current=$(git show HEAD:$file | yq ".version")
-          previous=$(git show HEAD^:$file | yq ".version")
+  #     - name: Check Helm version change
+  #       id: helm-version
+  #       if: steps.filter.outputs.helm-changes == 'true'
+  #       shell: bash
+  #       run: |
+  #         current=$(git show HEAD:$file | yq ".version")
+  #         previous=$(git show HEAD^:$file | yq ".version")
 
-          echo "version=$current" >> $GITHUB_OUTPUT
+  #         echo "version=$current" >> $GITHUB_OUTPUT
 
-          if [ "$current" != "$previous" ]; then
-            echo "Version field in $file was changed from $previous to $current"
-            echo "version_changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "Version field in $file was not changed"
-            echo "version_changed=false" >> $GITHUB_OUTPUT
-          fi
-        env:
-          file: k8s/distributed-chroma/Chart.yaml
+  #         if [ "$current" != "$previous" ]; then
+  #           echo "Version field in $file was changed from $previous to $current"
+  #           echo "version_changed=true" >> $GITHUB_OUTPUT
+  #         else
+  #           echo "Version field in $file was not changed"
+  #           echo "version_changed=false" >> $GITHUB_OUTPUT
+  #         fi
+  #       env:
+  #         file: k8s/distributed-chroma/Chart.yaml
 
-  deploy-docs-preview:
-    name: Deploy preview of docs
-    needs: change-detection
-    if: needs.change-detection.outputs.docs-only == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    environment:
-      name: Preview
-      url: ${{ steps.deploy.outputs.url }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "18.x"
-          registry-url: "https://registry.npmjs.org"
-      - name: Install vercel
-        run: npm install -g vercel
-      - name: Deploy
-        id: deploy
-        run: echo "url=$(vercel deploy --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
+  # deploy-docs-preview:
+  #   name: Deploy preview of docs
+  #   needs: change-detection
+  #   if: needs.change-detection.outputs.docs-only == 'true'
+  #   runs-on: blacksmith-4vcpu-ubuntu-2404
+  #   environment:
+  #     name: Preview
+  #     url: ${{ steps.deploy.outputs.url }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: "18.x"
+  #         registry-url: "https://registry.npmjs.org"
+  #     - name: Install vercel
+  #       run: npm install -g vercel
+  #     - name: Deploy
+  #       id: deploy
+  #       run: echo "url=$(vercel deploy --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+  #       env:
+  #         VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  #         VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
 
-  check-helm-version-bump:
-    name: Warn if Helm chart was updated without version bump
-    needs: change-detection
-    if: needs.change-detection.outputs.helm-changes == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Comment warning
-        if: needs.change-detection.outputs.helm-version-changed == 'false'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: helm-chart-version-info
-          message: |
-            :warning: The Helm chart was updated without a version bump. Your changes will only be published if the version field in `k8s/distributed-chroma/Chart.yaml` is updated.
+  # check-helm-version-bump:
+  #   name: Warn if Helm chart was updated without version bump
+  #   needs: change-detection
+  #   if: needs.change-detection.outputs.helm-changes == 'true'
+  #   runs-on: blacksmith-4vcpu-ubuntu-2404
+  #   permissions:
+  #     pull-requests: write
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Comment warning
+  #       if: needs.change-detection.outputs.helm-version-changed == 'false'
+  #       uses: marocchino/sticky-pull-request-comment@v2
+  #       with:
+  #         header: helm-chart-version-info
+  #         message: |
+  #           :warning: The Helm chart was updated without a version bump. Your changes will only be published if the version field in `k8s/distributed-chroma/Chart.yaml` is updated.
 
-      - name: Comment success
-        if: needs.change-detection.outputs.helm-version-changed == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: helm-chart-version-info
-          message: |
-            :white_check_mark: The Helm chart's version was changed. Your changes to the chart will be published upon merge to `main`.
+  #     - name: Comment success
+  #       if: needs.change-detection.outputs.helm-version-changed == 'true'
+  #       uses: marocchino/sticky-pull-request-comment@v2
+  #       with:
+  #         header: helm-chart-version-info
+  #         message: |
+  #           :white_check_mark: The Helm chart's version was changed. Your changes to the chart will be published upon merge to `main`.
 
-  delete-helm-comment:
-    name: Delete Helm chart comment if not changed
-    needs: change-detection
-    if: needs.change-detection.outputs.helm-changes == 'false'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Delete comment (Helm chart was not changed)
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: helm-chart-version-info
-          delete: true
+  # delete-helm-comment:
+  #   name: Delete Helm chart comment if not changed
+  #   needs: change-detection
+  #   if: needs.change-detection.outputs.helm-changes == 'false'
+  #   runs-on: blacksmith-4vcpu-ubuntu-2404
+  #   permissions:
+  #     pull-requests: write
+  #   steps:
+  #     - name: Delete comment (Helm chart was not changed)
+  #       uses: marocchino/sticky-pull-request-comment@v2
+  #       with:
+  #         header: helm-chart-version-info
+  #         delete: true
 
   python-tests:
     name: Python tests
-    needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
+    # needs: change-detection
+    # if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
     uses: ./.github/workflows/_python-tests.yml
     secrets: inherit
     permissions:
       contents: read
       id-token: write
     with:
-      property_testing_preset: 'normal'
+      property_testing_preset: "normal"
 
-  python-vulnerability-scan:
-    name: Python vulnerability scan
-    needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
-    uses: ./.github/workflows/_python-vulnerability-scan.yml
+  # python-vulnerability-scan:
+  #   name: Python vulnerability scan
+  #   needs: change-detection
+  #   if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
+  #   uses: ./.github/workflows/_python-vulnerability-scan.yml
 
-  javascript-client-tests:
-    name: JavaScript client tests
-    needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'js-client')
-    uses: ./.github/workflows/_javascript-client-tests.yml
+  # javascript-client-tests:
+  #   name: JavaScript client tests
+  #   needs: change-detection
+  #   if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'js-client')
+  #   uses: ./.github/workflows/_javascript-client-tests.yml
 
-  rust-tests:
-    name: Rust tests
-    needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
-    uses: ./.github/workflows/_rust-tests.yml
-    secrets: inherit
-    permissions:
-      contents: read
-      id-token: write
+  # rust-tests:
+  #   name: Rust tests
+  #   needs: change-detection
+  #   if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
+  #   uses: ./.github/workflows/_rust-tests.yml
+  #   secrets: inherit
+  #   permissions:
+  #     contents: read
+  #     id-token: write
 
-  go-tests:
-    name: Go tests
-    needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'go')
-    uses: ./.github/workflows/_go-tests.yml
-    secrets: inherit
-    permissions:
-      contents: read
-      id-token: write
+  # go-tests:
+  #   name: Go tests
+  #   needs: change-detection
+  #   if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'go')
+  #   uses: ./.github/workflows/_go-tests.yml
+  #   secrets: inherit
+  #   permissions:
+  #     contents: read
+  #     id-token: write
 
-  lint:
-    name: Lint
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - uses: ./.github/actions/python
-        with:
-          python-version: "3.11"
-      - name: Setup Rust
-        uses: ./.github/actions/rust
-        with:
-          github-token: ${{ github.token }}
-      - name: Run pre-commit
-        shell: bash
-        run: |
-          pre-commit run --all-files trailing-whitespace
-          pre-commit run --all-files mixed-line-ending
-          pre-commit run --all-files end-of-file-fixer
-          pre-commit run --all-files requirements-txt-fixer
-          pre-commit run --all-files check-xml
-          pre-commit run --all-files check-merge-conflict
-          pre-commit run --all-files check-case-conflict
-          pre-commit run --all-files check-docstring-first
-          pre-commit run --all-files black
-          pre-commit run --all-files flake8
-          pre-commit run --all-files prettier
-          pre-commit run --all-files check-yaml
-        continue-on-error: true
-      - name: Cargo fmt check
-        shell: bash
-        run: cargo fmt -- --check
-      - name: Clippy
-        run: cargo clippy --all-targets --all-features --keep-going -- -D warnings -D clippy::large_futures
+  # lint:
+  #   name: Lint
+  #   runs-on: blacksmith-4vcpu-ubuntu-2404
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - uses: ./.github/actions/python
+  #       with:
+  #         python-version: "3.11"
+  #     - name: Setup Rust
+  #       uses: ./.github/actions/rust
+  #       with:
+  #         github-token: ${{ github.token }}
+  #     - name: Run pre-commit
+  #       shell: bash
+  #       run: |
+  #         pre-commit run --all-files trailing-whitespace
+  #         pre-commit run --all-files mixed-line-ending
+  #         pre-commit run --all-files end-of-file-fixer
+  #         pre-commit run --all-files requirements-txt-fixer
+  #         pre-commit run --all-files check-xml
+  #         pre-commit run --all-files check-merge-conflict
+  #         pre-commit run --all-files check-case-conflict
+  #         pre-commit run --all-files check-docstring-first
+  #         pre-commit run --all-files black
+  #         pre-commit run --all-files flake8
+  #         pre-commit run --all-files prettier
+  #         pre-commit run --all-files check-yaml
+  #       continue-on-error: true
+  #     - name: Cargo fmt check
+  #       shell: bash
+  #       run: cargo fmt -- --check
+  #     - name: Clippy
+  #       run: cargo clippy --all-targets --all-features --keep-going -- -D warnings -D clippy::large_futures
 
   # This job exists for our branch protection rule.
   # We want to require status checks to pass before merging, but the set of
@@ -247,46 +247,46 @@ jobs:
   all-required-pr-checks-passed:
     if: always()
     needs:
-    - python-tests
-    - python-vulnerability-scan
-    - javascript-client-tests
-    - rust-tests
-    - go-tests
-    - lint
-    - check-helm-version-bump
-    - delete-helm-comment
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    steps:
-    - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{ toJSON(needs) }}
-        allowed-skips: python-tests,python-vulnerability-scan,javascript-client-tests,rust-tests,go-tests,check-helm-version-bump,delete-helm-comment
-
-  notify-slack-on-failure:
-    name: Notify Slack on Test Failure
-    if: github.ref == 'refs/heads/main' && failure()
-    needs:
-    - python-tests
-    - python-vulnerability-scan
-    - javascript-client-tests
-    - rust-tests
-    - go-tests
-    - lint
-    - check-helm-version-bump
-    - delete-helm-comment
+      - python-tests
+      # - python-vulnerability-scan
+      # - javascript-client-tests
+      # - rust-tests
+      # - go-tests
+      # - lint
+      # - check-helm-version-bump
+      # - delete-helm-comment
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.0.0
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
         with:
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          method: chat.postMessage
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: |
-              :x: *Test failure on main branch after PR merge!*
-              *Workflow:* ${{ github.workflow }}
-              *Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
-              *Ref:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>
-              *Author:* ${{ github.actor }}
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: python-tests,python-vulnerability-scan,javascript-client-tests,rust-tests,go-tests,check-helm-version-bump,delete-helm-comment
+
+  # notify-slack-on-failure:
+  #   name: Notify Slack on Test Failure
+  #   if: github.ref == 'refs/heads/main' && failure()
+  #   needs:
+  #     - python-tests
+  #     - python-vulnerability-scan
+  #     - javascript-client-tests
+  #     - rust-tests
+  #     - go-tests
+  #     - lint
+  #     - check-helm-version-bump
+  #     - delete-helm-comment
+  #   runs-on: blacksmith-2vcpu-ubuntu-2404
+  #   steps:
+  #     - name: Notify Slack
+  #       uses: slackapi/slack-github-action@v2.0.0
+  #       with:
+  #         token: ${{ secrets.SLACK_BOT_TOKEN }}
+  #         method: chat.postMessage
+  #         payload: |
+  #           channel: ${{ secrets.SLACK_CHANNEL_ID }}
+  #           text: |
+  #             :x: *Test failure on main branch after PR merge!*
+  #             *Workflow:* ${{ github.workflow }}
+  #             *Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
+  #             *Ref:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>
+  #             *Author:* ${{ github.actor }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -189,6 +189,9 @@ jobs:
     if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
     uses: ./.github/workflows/_rust-tests.yml
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
 
   go-tests:
     name: Go tests
@@ -196,6 +199,9 @@ jobs:
     if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'go')
     uses: ./.github/workflows/_go-tests.yml
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
 
   lint:
     name: Lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -165,6 +165,9 @@ jobs:
     if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
     uses: ./.github/workflows/_python-tests.yml
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
     with:
       property_testing_preset: 'normal'
 

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -56,8 +56,8 @@ jobs:
       # we only run windows tests on 3.12 because windows runners are expensive
       # and we usually don't see failures that are isolated to a specific version
       python_versions: '["3.12"]'
-      property_testing_preset: 'normal'
-      runner: '8core-32gb-windows-latest'
+      property_testing_preset: "normal"
+      runner: "blacksmith-8vcpu-windows-2025"
 
   javascript-client-tests:
     name: JavaScript client tests

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -6,11 +6,9 @@ on:
       - "*"
     branches:
       - main
-      # TEMPORARY BRANCH TO TEST BLACKSMITH WINDOWS RUNNERS
-      - ts/test-blacksmith-windows-runners
   schedule:
-    # Run every hour for testing Windows runners
-    - cron: "0 * * * *"
+    # TEMPORARY: Run every 30 minutes for benchmarking/testing Blacksmith Windows runners
+    - cron: "*/30 * * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -8,6 +8,13 @@ on:
       - main
       # TEMPORARY BRANCH TO TEST BLACKSMITH WINDOWS RUNNERS
       - ts/test-blacksmith-windows-runners
+  schedule:
+    # Run every hour for testing Windows runners
+    - cron: '0 * * * *'
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   check-tag:

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -6,6 +6,8 @@ on:
       - "*"
     branches:
       - main
+      # TEMPORARY BRANCH TO TEST BLACKSMITH WINDOWS RUNNERS
+      - ts/test-blacksmith-windows-runners
 
 jobs:
   check-tag:
@@ -49,8 +51,8 @@ jobs:
       python_versions: '["3.9", "3.10", "3.11", "3.12"]'
       property_testing_preset: "normal"
 
-  python-tests-windows:
-    name: Python tests Windows
+  python-tests-windows-blacksmith:
+    name: Python tests Windows (Blacksmith)
     uses: ./.github/workflows/_python-tests.yml
     secrets: inherit
     with:
@@ -58,7 +60,18 @@ jobs:
       # and we usually don't see failures that are isolated to a specific version
       python_versions: '["3.12"]'
       property_testing_preset: "normal"
-      runner: "windows"
+      runner: "blacksmith-staging-8vcpu-windows-2025"
+
+  python-tests-windows-github:
+    name: Python tests Windows (GitHub Large)
+    uses: ./.github/workflows/_python-tests.yml
+    secrets: inherit
+    with:
+      # we only run windows tests on 3.12 because windows runners are expensive
+      # and we usually don't see failures that are isolated to a specific version
+      python_versions: '["3.12"]'
+      property_testing_preset: "normal"
+      runner: "8core-32gb-windows-2025"
 
   javascript-client-tests:
     name: JavaScript client tests
@@ -80,7 +93,8 @@ jobs:
       - check-tag
       - get-version
       - python-tests-linux
-      - python-tests-windows
+      - python-tests-windows-blacksmith
+      - python-tests-windows-github
       - javascript-client-tests
       - rust-tests
       - go-tests
@@ -97,7 +111,8 @@ jobs:
       - check-tag
       - get-version
       - python-tests-linux
-      - python-tests-windows
+      - python-tests-windows-blacksmith
+      - python-tests-windows-github
       - javascript-client-tests
       - rust-tests
       - go-tests
@@ -114,7 +129,8 @@ jobs:
     needs:
       - check-tag
       - python-tests-linux
-      - python-tests-windows
+      - python-tests-windows-blacksmith
+      - python-tests-windows-github
       - javascript-client-tests
       - rust-tests
       - go-tests

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -57,7 +57,7 @@ jobs:
       # and we usually don't see failures that are isolated to a specific version
       python_versions: '["3.12"]'
       property_testing_preset: "normal"
-      runner: "blacksmith-8vcpu-windows-2025"
+      runner: "blacksmith-staging-8vcpu-windows-2025"
 
   javascript-client-tests:
     name: JavaScript client tests

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: "3.9"
       - name: Install setuptools_scm
         run: python -m pip install setuptools_scm
       - name: Get Release Version
@@ -47,7 +47,7 @@ jobs:
     secrets: inherit
     with:
       python_versions: '["3.9", "3.10", "3.11", "3.12"]'
-      property_testing_preset: 'normal'
+      property_testing_preset: "normal"
 
   python-tests-windows:
     uses: ./.github/workflows/_python-tests.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Set up Python
         uses: ./.github/actions/python
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - name: Build Client
         run: ./clients/python/build_python_thin_client.sh
       - name: Test Client Package
@@ -137,13 +137,13 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_PYTHON_CLIENT_PUBLISH_KEY }}
           repository-url: https://test.pypi.org/legacy/
-          verbose: 'true'
+          verbose: "true"
       - name: Publish to PyPI
-        if:  ${{ needs.check-tag.outputs.tag_matches == 'true' }}
+        if: ${{ needs.check-tag.outputs.tag_matches == 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_PYTHON_CLIENT_PUBLISH_KEY }}
-          verbose: 'true'
+          verbose: "true"
 
   release-github:
     name: Make GitHub release

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -50,6 +50,7 @@ jobs:
       property_testing_preset: "normal"
 
   python-tests-windows:
+    name: Python tests Windows
     uses: ./.github/workflows/_python-tests.yml
     secrets: inherit
     with:
@@ -57,7 +58,7 @@ jobs:
       # and we usually don't see failures that are isolated to a specific version
       python_versions: '["3.12"]'
       property_testing_preset: "normal"
-      runner: "blacksmith-staging-8vcpu-windows-2025"
+      runner: "windows"
 
   javascript-client-tests:
     name: JavaScript client tests

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -10,7 +10,7 @@ on:
       - ts/test-blacksmith-windows-runners
   schedule:
     # Run every hour for testing Windows runners
-    - cron: '0 * * * *'
+    - cron: "0 * * * *"
 
 permissions:
   contents: read
@@ -94,23 +94,23 @@ jobs:
     uses: ./.github/workflows/_go-tests.yml
     secrets: inherit
 
-  release-docker:
-    name: Publish to DockerHub and GHCR
-    needs:
-      - check-tag
-      - get-version
-      - python-tests-linux
-      - python-tests-windows-blacksmith
-      - python-tests-windows-github
-      - javascript-client-tests
-      - rust-tests
-      - go-tests
-    uses: ./.github/workflows/_build_release_container.yml
-    secrets: inherit
-    with:
-      tag: ${{ needs.get-version.outputs.version }}
-      tag_as_latest: ${{ needs.check-tag.outputs.tag_matches == 'true' }}
-      push: true
+  # release-docker:
+  #   name: Publish to DockerHub and GHCR
+  #   needs:
+  #     - check-tag
+  #     - get-version
+  #     - python-tests-linux
+  #     - python-tests-windows-blacksmith
+  #     - python-tests-windows-github
+  #     - javascript-client-tests
+  #     - rust-tests
+  #     - go-tests
+  #   uses: ./.github/workflows/_build_release_container.yml
+  #   secrets: inherit
+  #   with:
+  #     tag: ${{ needs.get-version.outputs.version }}
+  #     tag_as_latest: ${{ needs.check-tag.outputs.tag_matches == 'true' }}
+  #     push: true
 
   release-pypi:
     name: Publish to PyPI
@@ -130,159 +130,159 @@ jobs:
       publish_to_pypi: ${{ needs.check-tag.outputs.tag_matches == 'true' }}
       version: ${{ needs.get-version.outputs.version }}
 
-  release-thin-pypi:
-    name: Publish thin client to PyPI
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs:
-      - check-tag
-      - python-tests-linux
-      - python-tests-windows-blacksmith
-      - python-tests-windows-github
-      - javascript-client-tests
-      - rust-tests
-      - go-tests
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up Python
-        uses: ./.github/actions/python
-        with:
-          python-version: "3.12"
-      - name: Build Client
-        run: ./clients/python/build_python_thin_client.sh
-      - name: Test Client Package
-        run: bin/test-package/test-thin-client-package.sh dist/*.tar.gz
-      - name: Install setuptools_scm
-        run: python -m pip install setuptools_scm
-      - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_PYTHON_CLIENT_PUBLISH_KEY }}
-          repository-url: https://test.pypi.org/legacy/
-          verbose: "true"
-      - name: Publish to PyPI
-        if: ${{ needs.check-tag.outputs.tag_matches == 'true' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_PYTHON_CLIENT_PUBLISH_KEY }}
-          verbose: "true"
+  # release-thin-pypi:
+  #   name: Publish thin client to PyPI
+  #   runs-on: blacksmith-4vcpu-ubuntu-2404
+  #   needs:
+  #     - check-tag
+  #     - python-tests-linux
+  #     - python-tests-windows-blacksmith
+  #     - python-tests-windows-github
+  #     - javascript-client-tests
+  #     - rust-tests
+  #     - go-tests
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Set up Python
+  #       uses: ./.github/actions/python
+  #       with:
+  #         python-version: "3.12"
+  #     - name: Build Client
+  #       run: ./clients/python/build_python_thin_client.sh
+  #     - name: Test Client Package
+  #       run: bin/test-package/test-thin-client-package.sh dist/*.tar.gz
+  #     - name: Install setuptools_scm
+  #       run: python -m pip install setuptools_scm
+  #     - name: Publish to Test PyPI
+  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         password: ${{ secrets.TEST_PYPI_PYTHON_CLIENT_PUBLISH_KEY }}
+  #         repository-url: https://test.pypi.org/legacy/
+  #         verbose: "true"
+  #     - name: Publish to PyPI
+  #       if: ${{ needs.check-tag.outputs.tag_matches == 'true' }}
+  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         password: ${{ secrets.PYPI_PYTHON_CLIENT_PUBLISH_KEY }}
+  #         verbose: "true"
 
-  release-github:
-    name: Make GitHub release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs:
-      - check-tag
-      - get-version
-      - release-docker
-      - release-pypi
-      - release-thin-pypi
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          pattern: wheels-*
-          path: dist
-      - name: Get current date
-        id: builddate
-        run: echo "builddate=$(date +'%Y-%m-%dT%H:%M')" >> $GITHUB_OUTPUT
-      - name: Release Tagged Version
-        uses: ncipollo/release-action@v1.14.0
-        if: ${{ needs.check-tag.outputs.tag_matches == 'true' }}
-        with:
-          body: |
-            Version: `${{needs.get-version.outputs.version}}`
-            Git ref: `${{github.ref}}`
-            Build Date: `${{steps.builddate.outputs.builddate}}`
-            PIP Package: `chroma-${{needs.get-version.outputs.version}}.tar.gz`
-            Github Container Registry Image: `${{ env.GHCR_IMAGE_NAME }}:${{ needs.get-version.outputs.version }}`
-            DockerHub Image: `${{ env.DOCKERHUB_IMAGE_NAME }}:${{ needs.get-version.outputs.version }}`
-          artifacts: "dist/*"
-          prerelease: false
-          makeLatest: true
-          generateReleaseNotes: true
-      - name: Update Tag
-        uses: richardsimko/update-tag@v1.0.5
-        if: ${{ needs.check-tag.outputs.tag_matches != 'true' }}
-        with:
-          tag_name: latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Release Latest
-        uses: ncipollo/release-action@v1.14.0
-        if: ${{ needs.check-tag.outputs.tag_matches != 'true' }}
-        with:
-          tag: "latest"
-          name: "Latest"
-          body: |
-            Version: `${{needs.get-version.outputs.version}}`
-            Git ref: `${{github.ref}}`
-            Build Date: `${{steps.builddate.outputs.builddate}}`
-            PIP Package: `chroma-${{needs.get-version.outputs.version}}.tar.gz`
-            Github Container Registry Image: `${{ env.GHCR_IMAGE_NAME }}:${{ needs.get-version.outputs.version }}`
-            DockerHub Image: `${{ env.DOCKERHUB_IMAGE_NAME }}:${{ needs.get-version.outputs.version }}`
-          artifacts: "dist/*"
-          allowUpdates: true
-          removeArtifacts: true
-          prerelease: true
+  # release-github:
+  #   name: Make GitHub release
+  #   runs-on: blacksmith-4vcpu-ubuntu-2404
+  #   needs:
+  #     - check-tag
+  #     - get-version
+  #     - release-docker
+  #     - release-pypi
+  #     - release-thin-pypi
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Download artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         pattern: wheels-*
+  #         path: dist
+  #     - name: Get current date
+  #       id: builddate
+  #       run: echo "builddate=$(date +'%Y-%m-%dT%H:%M')" >> $GITHUB_OUTPUT
+  #     - name: Release Tagged Version
+  #       uses: ncipollo/release-action@v1.14.0
+  #       if: ${{ needs.check-tag.outputs.tag_matches == 'true' }}
+  #       with:
+  #         body: |
+  #           Version: `${{needs.get-version.outputs.version}}`
+  #           Git ref: `${{github.ref}}`
+  #           Build Date: `${{steps.builddate.outputs.builddate}}`
+  #           PIP Package: `chroma-${{needs.get-version.outputs.version}}.tar.gz`
+  #           Github Container Registry Image: `${{ env.GHCR_IMAGE_NAME }}:${{ needs.get-version.outputs.version }}`
+  #           DockerHub Image: `${{ env.DOCKERHUB_IMAGE_NAME }}:${{ needs.get-version.outputs.version }}`
+  #         artifacts: "dist/*"
+  #         prerelease: false
+  #         makeLatest: true
+  #         generateReleaseNotes: true
+  #     - name: Update Tag
+  #       uses: richardsimko/update-tag@v1.0.5
+  #       if: ${{ needs.check-tag.outputs.tag_matches != 'true' }}
+  #       with:
+  #         tag_name: latest
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Release Latest
+  #       uses: ncipollo/release-action@v1.14.0
+  #       if: ${{ needs.check-tag.outputs.tag_matches != 'true' }}
+  #       with:
+  #         tag: "latest"
+  #         name: "Latest"
+  #         body: |
+  #           Version: `${{needs.get-version.outputs.version}}`
+  #           Git ref: `${{github.ref}}`
+  #           Build Date: `${{steps.builddate.outputs.builddate}}`
+  #           PIP Package: `chroma-${{needs.get-version.outputs.version}}.tar.gz`
+  #           Github Container Registry Image: `${{ env.GHCR_IMAGE_NAME }}:${{ needs.get-version.outputs.version }}`
+  #           DockerHub Image: `${{ env.DOCKERHUB_IMAGE_NAME }}:${{ needs.get-version.outputs.version }}`
+  #         artifacts: "dist/*"
+  #         allowUpdates: true
+  #         removeArtifacts: true
+  #         prerelease: true
 
-  deploy-staging:
-    name: Deploy to staging
-    # depends on release-github because it updates the tag to latest, which is what will get deployed
-    needs:
-      - release-github
-    uses: ./.github/workflows/_deploy.yml
-    secrets: inherit
+  # deploy-staging:
+  #   name: Deploy to staging
+  #   # depends on release-github because it updates the tag to latest, which is what will get deployed
+  #   needs:
+  #     - release-github
+  #   uses: ./.github/workflows/_deploy.yml
+  #   secrets: inherit
 
-  release-docs:
-    name: Deploy docs to Vercel
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs:
-      - check-tag
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "18.x"
-          registry-url: "https://registry.npmjs.org"
-      - name: Install vercel
-        run: npm install -g vercel
-      - name: Deploy
-        run: vercel deploy --token ${{ secrets.VERCEL_TOKEN }} ${{ needs.check-tag.outputs.tag_matches == 'true' && '--prod' || '' }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
+  # release-docs:
+  #   name: Deploy docs to Vercel
+  #   runs-on: blacksmith-4vcpu-ubuntu-2404
+  #   needs:
+  #     - check-tag
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: "18.x"
+  #         registry-url: "https://registry.npmjs.org"
+  #     - name: Install vercel
+  #       run: npm install -g vercel
+  #     - name: Deploy
+  #       run: vercel deploy --token ${{ secrets.VERCEL_TOKEN }} ${{ needs.check-tag.outputs.tag_matches == 'true' && '--prod' || '' }}
+  #       env:
+  #         VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  #         VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
 
-  notify-slack-on-failure:
-    name: Notify Slack on ChromaDB Release Failure
-    if: failure()
-    needs:
-      - release-docker
-      - release-pypi
-      - release-thin-pypi
-      - release-github
-      - deploy-staging
-      - release-docs
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    steps:
-      - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          method: chat.postMessage
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: |
-              :x: *ChromaDB release failure!*
-              *Workflow:* ${{ github.workflow }}
-              *Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
-              *Ref:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>
-              *Author:* ${{ github.actor }}
+  # notify-slack-on-failure:
+  #   name: Notify Slack on ChromaDB Release Failure
+  #   if: failure()
+  #   needs:
+  #     - release-docker
+  #     - release-pypi
+  #     - release-thin-pypi
+  #     - release-github
+  #     - deploy-staging
+  #     - release-docs
+  #   runs-on: blacksmith-2vcpu-ubuntu-2404
+  #   steps:
+  #     - name: Notify Slack
+  #       uses: slackapi/slack-github-action@v2.0.0
+  #       with:
+  #         token: ${{ secrets.SLACK_BOT_TOKEN }}
+  #         method: chat.postMessage
+  #         payload: |
+  #           channel: ${{ secrets.SLACK_CHANNEL_ID }}
+  #           text: |
+  #             :x: *ChromaDB release failure!*
+  #             *Workflow:* ${{ github.workflow }}
+  #             *Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
+  #             *Ref:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>
+  #             *Author:* ${{ github.actor }}

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -51,12 +51,12 @@ jobs:
         id: version
         run: echo "version=$(python -m setuptools_scm)" >> $GITHUB_OUTPUT
 
-  python-tests-linux:
-    uses: ./.github/workflows/_python-tests.yml
-    secrets: inherit
-    with:
-      python_versions: '["3.9", "3.10", "3.11", "3.12"]'
-      property_testing_preset: "normal"
+  # python-tests-linux:
+  #   uses: ./.github/workflows/_python-tests.yml
+  #   secrets: inherit
+  #   with:
+  #     python_versions: '["3.9", "3.10", "3.11", "3.12"]'
+  #     property_testing_preset: "normal"
 
   python-tests-windows-blacksmith:
     name: Python tests Windows (Blacksmith)
@@ -80,19 +80,19 @@ jobs:
       property_testing_preset: "normal"
       runner: "8core-32gb-windows-2025"
 
-  javascript-client-tests:
-    name: JavaScript client tests
-    uses: ./.github/workflows/_javascript-client-tests.yml
+  # javascript-client-tests:
+  #   name: JavaScript client tests
+  #   uses: ./.github/workflows/_javascript-client-tests.yml
 
-  rust-tests:
-    name: Rust tests
-    uses: ./.github/workflows/_rust-tests.yml
-    secrets: inherit
+  # rust-tests:
+  #   name: Rust tests
+  #   uses: ./.github/workflows/_rust-tests.yml
+  #   secrets: inherit
 
-  go-tests:
-    name: Go tests
-    uses: ./.github/workflows/_go-tests.yml
-    secrets: inherit
+  # go-tests:
+  #   name: Go tests
+  #   uses: ./.github/workflows/_go-tests.yml
+  #   secrets: inherit
 
   # release-docker:
   #   name: Publish to DockerHub and GHCR
@@ -117,12 +117,12 @@ jobs:
     needs:
       - check-tag
       - get-version
-      - python-tests-linux
+      # - python-tests-linux
       - python-tests-windows-blacksmith
       - python-tests-windows-github
-      - javascript-client-tests
-      - rust-tests
-      - go-tests
+      # - javascript-client-tests
+      # - rust-tests
+      # - go-tests
     uses: ./.github/workflows/_build_release_pypi.yml
     secrets: inherit
     with:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -43,7 +43,7 @@ jobs:
 
   build-windows:
     name: Build Windows binary
-    runs-on: 8core-32gb-windows-latest
+    runs-on: blacksmith-8vcpu-windows-2025
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -47,8 +47,8 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - [blacksmith-staging-4vcpu-windows-2025, bs-dev-taha]
-          - windows-2025
+          - blacksmith-staging-8vcpu-windows-2025
+          - 8core-32gb-windows-2025
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
@@ -76,7 +76,7 @@ jobs:
       - name: Upload Windows binary artifact
         uses: actions/upload-artifact@v4
         with:
-          name: chroma-windows
+          name: chroma-windows-${{ matrix.runner == '8core-32gb-windows-2025' && 'github' || 'blacksmith' }}
           path: chroma-windows.exe
 
   # build-macos:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -9,6 +9,9 @@ on:
   push:
     tags:
       - "cli_release_[0-9]*.[0-9]*.[0-9]*"
+  schedule:
+    # Run every hour for testing Windows runners
+    - cron: '0 * * * *'
 
 jobs:
   # build-linux:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -43,7 +43,7 @@ jobs:
 
   build-windows:
     name: Build Windows binary
-    runs-on: blacksmith-8vcpu-windows-2025
+    runs-on: blacksmith-staging-8vcpu-windows-2025
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -11,35 +11,35 @@ on:
       - "cli_release_[0-9]*.[0-9]*.[0-9]*"
 
 jobs:
-  build-linux:
-    name: Build Linux binary
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  # build-linux:
+  #   name: Build Linux binary
+  #   runs-on: blacksmith-4vcpu-ubuntu-2404
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Install Protoc
+  #       uses: arduino/setup-protoc@v3
+  #       with:
+  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+  #     - name: Set up Rust toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         override: true
 
-      - name: Build Linux binary
-        run: cargo build --bin chroma --release --manifest-path rust/cli/Cargo.toml
+  #     - name: Build Linux binary
+  #       run: cargo build --bin chroma --release --manifest-path rust/cli/Cargo.toml
 
-      - name: Rename binary artifact for Linux
-        run: mv target/release/chroma ./chroma-linux
+  #     - name: Rename binary artifact for Linux
+  #       run: mv target/release/chroma ./chroma-linux
 
-      - name: Upload Linux binary artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: chroma-linux
-          path: chroma-linux
+  #     - name: Upload Linux binary artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: chroma-linux
+  #         path: chroma-linux
 
   build-windows:
     name: Build Windows binary
@@ -73,134 +73,134 @@ jobs:
           name: chroma-windows
           path: chroma-windows.exe
 
-  build-macos:
-    name: Build macOS binaries (Intel & ARM64)
-    runs-on: macos-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  # build-macos:
+  #   name: Build macOS binaries (Intel & ARM64)
+  #   runs-on: macos-latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
 
-      - name: Install Protocol Buffers Compiler
-        run: brew install protobuf
+  #     - name: Install Protocol Buffers Compiler
+  #       run: brew install protobuf
 
-      - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+  #     - name: Set up Rust toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         override: true
 
-      - name: Add ARM64 target for macOS
-        run: rustup target add aarch64-apple-darwin
+  #     - name: Add ARM64 target for macOS
+  #       run: rustup target add aarch64-apple-darwin
 
-      - name: Add Intel target for macOS
-        run: rustup target add x86_64-apple-darwin
+  #     - name: Add Intel target for macOS
+  #       run: rustup target add x86_64-apple-darwin
 
-      - name: Build macOS Intel binary
-        run: cargo build --bin chroma --release --target x86_64-apple-darwin --manifest-path rust/cli/Cargo.toml
+  #     - name: Build macOS Intel binary
+  #       run: cargo build --bin chroma --release --target x86_64-apple-darwin --manifest-path rust/cli/Cargo.toml
 
-      - name: Build macOS ARM64 binary
-        run: cargo build --bin chroma --release --target aarch64-apple-darwin --manifest-path rust/cli/Cargo.toml
+  #     - name: Build macOS ARM64 binary
+  #       run: cargo build --bin chroma --release --target aarch64-apple-darwin --manifest-path rust/cli/Cargo.toml
 
-      - name: Rename macOS binaries
-        run: |
-          mv target/x86_64-apple-darwin/release/chroma ./chroma-macos-intel
-          mv target/aarch64-apple-darwin/release/chroma ./chroma-macos-arm64
-          chmod +x ./chroma-macos-intel ./chroma-macos-arm64
+  #     - name: Rename macOS binaries
+  #       run: |
+  #         mv target/x86_64-apple-darwin/release/chroma ./chroma-macos-intel
+  #         mv target/aarch64-apple-darwin/release/chroma ./chroma-macos-arm64
+  #         chmod +x ./chroma-macos-intel ./chroma-macos-arm64
 
-      - name: Upload macOS Intel binary artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: chroma-macos-intel
-          path: chroma-macos-intel
+  #     - name: Upload macOS Intel binary artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: chroma-macos-intel
+  #         path: chroma-macos-intel
 
-      - name: Upload macOS ARM64 binary artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: chroma-macos-arm64
-          path: chroma-macos-arm64
+  #     - name: Upload macOS ARM64 binary artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: chroma-macos-arm64
+  #         path: chroma-macos-arm64
 
-  release:
-    name: Create GitHub Release and Attach Assets
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [build-linux, build-windows, build-macos]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  # release:
+  #   name: Create GitHub Release and Attach Assets
+  #   runs-on: blacksmith-4vcpu-ubuntu-2404
+  #   needs: [build-linux, build-windows, build-macos]
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
 
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
+  #     - name: Download all artifacts
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         path: artifacts
 
-      - name: Ensure all binaries are executable
-        run: chmod +x artifacts/* || true
+  #     - name: Ensure all binaries are executable
+  #       run: chmod +x artifacts/* || true
 
-      - name: Determine release info
-        id: release_info
-        run: |
-          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
-            # The tag is available as refs/tags/cli_release_a.b.c.
-            TAG=${GITHUB_REF#refs/tags/}
-            VERSION=${TAG#cli_release_}
-            echo "release_name=cli-${VERSION}" >> $GITHUB_OUTPUT
-            echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
-          else
-            if [ -z "${{ github.event.inputs.release_name }}" ]; then
-              echo "::error::Manual dispatch requires a release_name input."
-              exit 1
-            fi
-            echo "release_name=${{ github.event.inputs.release_name }}" >> $GITHUB_OUTPUT
-            echo "tag_name=${{ github.event.inputs.release_name }}" >> $GITHUB_OUTPUT
-          fi
+  #     - name: Determine release info
+  #       id: release_info
+  #       run: |
+  #         if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+  #           # The tag is available as refs/tags/cli_release_a.b.c.
+  #           TAG=${GITHUB_REF#refs/tags/}
+  #           VERSION=${TAG#cli_release_}
+  #           echo "release_name=cli-${VERSION}" >> $GITHUB_OUTPUT
+  #           echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
+  #         else
+  #           if [ -z "${{ github.event.inputs.release_name }}" ]; then
+  #             echo "::error::Manual dispatch requires a release_name input."
+  #             exit 1
+  #           fi
+  #           echo "release_name=${{ github.event.inputs.release_name }}" >> $GITHUB_OUTPUT
+  #           echo "tag_name=${{ github.event.inputs.release_name }}" >> $GITHUB_OUTPUT
+  #         fi
 
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.release_info.outputs.tag_name }}
-          release_name: ${{ steps.release_info.outputs.release_name }}
-          body: "CLI release."
-          draft: false
-          prerelease: false
+  #     - name: Create GitHub Release
+  #       id: create_release
+  #       uses: actions/create-release@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         tag_name: ${{ steps.release_info.outputs.tag_name }}
+  #         release_name: ${{ steps.release_info.outputs.release_name }}
+  #         body: "CLI release."
+  #         draft: false
+  #         prerelease: false
 
-      - name: Upload Linux binary to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/chroma-linux/chroma-linux
-          asset_name: chroma-linux
-          asset_content_type: application/octet-stream
+  #     - name: Upload Linux binary to release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create_release.outputs.upload_url }}
+  #         asset_path: artifacts/chroma-linux/chroma-linux
+  #         asset_name: chroma-linux
+  #         asset_content_type: application/octet-stream
 
-      - name: Upload Windows binary to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/chroma-windows/chroma-windows.exe
-          asset_name: chroma-windows.exe
-          asset_content_type: application/octet-stream
+  #     - name: Upload Windows binary to release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create_release.outputs.upload_url }}
+  #         asset_path: artifacts/chroma-windows/chroma-windows.exe
+  #         asset_name: chroma-windows.exe
+  #         asset_content_type: application/octet-stream
 
-      - name: Upload macOS Intel binary to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/chroma-macos-intel/chroma-macos-intel
-          asset_name: chroma-macos-intel
-          asset_content_type: application/octet-stream
+  #     - name: Upload macOS Intel binary to release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create_release.outputs.upload_url }}
+  #         asset_path: artifacts/chroma-macos-intel/chroma-macos-intel
+  #         asset_name: chroma-macos-intel
+  #         asset_content_type: application/octet-stream
 
-      - name: Upload macOS ARM64 binary to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/chroma-macos-arm64/chroma-macos-arm64
-          asset_name: chroma-macos-arm64
-          asset_content_type: application/octet-stream
+  #     - name: Upload macOS ARM64 binary to release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create_release.outputs.upload_url }}
+  #         asset_path: artifacts/chroma-macos-arm64/chroma-macos-arm64
+  #         asset_name: chroma-macos-arm64
+  #         asset_content_type: application/octet-stream

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -42,8 +42,14 @@ jobs:
   #         path: chroma-linux
 
   build-windows:
-    name: Build Windows binary
-    runs-on: blacksmith-staging-8vcpu-windows-2025
+    name: Build Windows binary (${{ matrix.runner }})
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - [blacksmith-staging-4vcpu-windows-2025, bs-dev-taha]
+          - windows-2025
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -8,7 +8,7 @@ on:
         required: false
   push:
     tags:
-      - 'cli_release_[0-9]*.[0-9]*.[0-9]*'
+      - "cli_release_[0-9]*.[0-9]*.[0-9]*"
 
 jobs:
   build-linux:
@@ -98,7 +98,6 @@ jobs:
       - name: Build macOS Intel binary
         run: cargo build --bin chroma --release --target x86_64-apple-darwin --manifest-path rust/cli/Cargo.toml
 
-
       - name: Build macOS ARM64 binary
         run: cargo build --bin chroma --release --target aarch64-apple-darwin --manifest-path rust/cli/Cargo.toml
 
@@ -123,7 +122,7 @@ jobs:
   release:
     name: Create GitHub Release and Attach Assets
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [ build-linux, build-windows, build-macos ]
+    needs: [build-linux, build-windows, build-macos]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -10,8 +10,8 @@ on:
     tags:
       - "cli_release_[0-9]*.[0-9]*.[0-9]*"
   schedule:
-    # Run every hour for testing Windows runners
-    - cron: '0 * * * *'
+    # TEMPORARY: Run every 30 minutes for benchmarking/testing Blacksmith Windows runners
+    - cron: "*/30 * * * *"
 
 jobs:
   # build-linux:


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- New functionality
  - Temporarily comment out now-windows jobs
  - Temporarily add schedules to workflows that call windows jobs
  - Temporarily turn windows jobs in matrix jobs that run against blacksmith staging 8vcpu runners as well as 8vcpu github hosted runners

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
