### PR TITLE
Test CI: Python tests on prod and staging runners

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   test-rust-bindings:
+    if: false
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -60,6 +61,7 @@ jobs:
           RUST_BACKTRACE: 1
 
   test-rust-single-node-integration:
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -92,6 +94,7 @@ jobs:
         PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
   test-rust-thin-client:
+    if: false
     strategy:
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
@@ -121,8 +124,25 @@ jobs:
           ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
-  test-cluster-rust-frontend:
+  test-tilt-startup:
     if: ${{ contains(inputs.runner, 'ubuntu') }}
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Docker
+        uses: ./.github/actions/docker
+        with:
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Start Tilt services
+        uses: ./.github/actions/tilt
+      - name: Verify Tilt started
+        run: echo "Tilt services started successfully"
+        shell: bash
+
+  test-cluster-rust-frontend:
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -195,7 +215,7 @@ jobs:
           artifact-name: ${{ steps.compute-artifact-name.outputs.artifact_name }}
 
   merge-cluster-logs:
-    if: ${{ contains(inputs.runner, 'ubuntu') }}
+    if: false
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: test-cluster-rust-frontend
     steps:
@@ -206,6 +226,7 @@ jobs:
           pattern: cluster_logs_*
 
   test-rust-bindings-stress:
+    if: false
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -238,6 +259,7 @@ jobs:
           CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
 
   test-python-cli:
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -270,7 +292,7 @@ jobs:
     # only run windows smoke tests when the runner isn't already windows,
     # also only run the smoke tests on PRs (ie not main and not tags) since
     # we are already running the full suite on Windows in those cases
-    if: ${{ !contains(inputs.runner, 'windows') && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+    if: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -130,6 +130,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Clear DNS cache
+        run: |
+          echo "Clearing DNS cache to avoid flakiness"
+          sudo resolvectl flush-caches || true
+          sudo systemctl restart systemd-resolved || true
+          echo "DNS cache cleared"
+        shell: bash
       - name: Setup Docker
         uses: ./.github/actions/docker
         with:
@@ -139,12 +146,6 @@ jobs:
         uses: ./.github/actions/tilt
       - name: Verify Tilt started
         run: echo "Tilt services started successfully"
-        shell: bash
-      - name: Sleep for debugging
-        run: |
-          echo "Sleeping for 2 hours to allow SSH debugging..."
-          echo "Connect via SSH to investigate the environment"
-          sleep 7200
         shell: bash
 
   test-cluster-rust-frontend:

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -177,10 +177,6 @@ jobs:
           - test-glob: "chromadb/test/property/test_collections_with_database_tenant_overwrite.py"
             multi_region: true
     runs-on: ${{ inputs.runner }}
-    # OIDC token auth for AWS
-    permissions:
-      contents: read
-      id-token: write
     env:
       MULTI_REGION: ${{ matrix.multi_region && 'true' || '' }}
     steps:

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       runner:
-        description: 'Runner to test on (string)'
+        description: 'Runner to test on (string or JSON array of labels)'
         required: false
         default: 'blacksmith-8vcpu-ubuntu-2404'
         type: string
@@ -126,7 +126,7 @@ jobs:
 
   test-tilt-startup:
     if: ${{ contains(inputs.runner, 'ubuntu') }}
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ startsWith(inputs.runner, '[') && fromJSON(inputs.runner) || inputs.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -140,6 +140,12 @@ jobs:
       - name: Verify Tilt started
         run: echo "Tilt services started successfully"
         shell: bash
+      - name: Sleep for debugging
+        run: |
+          echo "Sleeping for 2 hours to allow SSH debugging..."
+          echo "Connect via SSH to investigate the environment"
+          sleep 7200
+        shell: bash
 
   test-cluster-rust-frontend:
     if: false

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -156,7 +156,7 @@ jobs:
             multi_region: true
           - test-glob: "chromadb/test/property/test_collections_with_database_tenant_overwrite.py"
             multi_region: true
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ${{ inputs.runner }}
     # OIDC token auth for AWS
     permissions:
       contents: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -185,36 +185,38 @@ jobs:
 
   python-vulnerability-scan:
     name: Python vulnerability scan
-    needs: change-detection
     if: false
-    uses: ./.github/workflows/_python-vulnerability-scan.yml
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - run: echo "Skipped"
 
   javascript-client-tests:
     name: JavaScript client tests
-    needs: change-detection
     if: false
-    uses: ./.github/workflows/_javascript-client-tests.yml
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - run: echo "Skipped"
 
   rust-tests:
     name: Rust tests
-    needs: change-detection
     if: false
-    uses: ./.github/workflows/_rust-tests.yml
-    secrets: inherit
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - run: echo "Skipped"
 
   rust-feature-tests:
     name: Rust feature tests
-    needs: change-detection
     if: false
-    uses: ./.github/workflows/_check_rust_release.yml
-    secrets: inherit
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - run: echo "Skipped"
 
   go-tests:
     name: Go tests
-    needs: change-detection
     if: false
-    uses: ./.github/workflows/_go-tests.yml
-    secrets: inherit
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - run: echo "Skipped"
 
   lint:
     name: Lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -165,49 +165,55 @@ jobs:
           delete: true
 
   python-tests:
-    name: Python tests
-    needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
+    name: Python tests (${{ matrix.runner }})
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - blacksmith-8vcpu-ubuntu-2404
+          - blacksmith-staging-8vcpu-ubuntu-2404
     uses: ./.github/workflows/_python-tests.yml
     secrets: inherit
     with:
       property_testing_preset: 'normal'
+      runner: ${{ matrix.runner }}
 
   python-vulnerability-scan:
     name: Python vulnerability scan
     needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
+    if: false
     uses: ./.github/workflows/_python-vulnerability-scan.yml
 
   javascript-client-tests:
     name: JavaScript client tests
     needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'js-client')
+    if: false
     uses: ./.github/workflows/_javascript-client-tests.yml
 
   rust-tests:
     name: Rust tests
     needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
+    if: false
     uses: ./.github/workflows/_rust-tests.yml
     secrets: inherit
 
   rust-feature-tests:
     name: Rust feature tests
     needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
+    if: false
     uses: ./.github/workflows/_check_rust_release.yml
     secrets: inherit
 
   go-tests:
     name: Go tests
     needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'go')
+    if: false
     uses: ./.github/workflows/_go-tests.yml
     secrets: inherit
 
   lint:
     name: Lint
+    if: false
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -183,6 +183,14 @@ jobs:
       property_testing_preset: 'normal'
       runner: 'blacksmith-staging-8vcpu-ubuntu-2404'
 
+  python-tests-dev:
+    name: Python tests (dev)
+    uses: ./.github/workflows/_python-tests.yml
+    secrets: inherit
+    with:
+      property_testing_preset: 'normal'
+      runner: 'bs-dev-paul'
+
   python-vulnerability-scan:
     name: Python vulnerability scan
     if: false
@@ -265,6 +273,7 @@ jobs:
     needs:
     - python-tests-prod
     - python-tests-staging
+    - python-tests-dev
     - python-vulnerability-scan
     - javascript-client-tests
     - rust-tests
@@ -279,7 +288,7 @@ jobs:
       uses: re-actors/alls-green@release/v1
       with:
         jobs: ${{ toJSON(needs) }}
-        allowed-skips: python-tests-prod,python-tests-staging,python-vulnerability-scan,javascript-client-tests,rust-tests,rust-feature-tests,go-tests,check-helm-version-bump,delete-helm-comment
+        allowed-skips: python-tests-prod,python-tests-staging,python-tests-dev,python-vulnerability-scan,javascript-client-tests,rust-tests,rust-feature-tests,go-tests,check-helm-version-bump,delete-helm-comment
 
   notify-slack-on-failure:
     name: Notify Slack on Test Failure
@@ -287,6 +296,7 @@ jobs:
     needs:
     - python-tests-prod
     - python-tests-staging
+    - python-tests-dev
     - python-vulnerability-scan
     - javascript-client-tests
     - rust-tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -189,7 +189,7 @@ jobs:
     secrets: inherit
     with:
       property_testing_preset: 'normal'
-      runner: 'bs-dev-paul'
+      runner: '["blacksmith-staging-8vcpu-ubuntu-2404", "bs-dev-paul"]'
 
   python-vulnerability-scan:
     name: Python vulnerability scan

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -167,19 +167,21 @@ jobs:
           header: helm-chart-version-info
           delete: true
 
-  python-tests:
-    name: Python tests (${{ matrix.runner }})
-    strategy:
-      fail-fast: false
-      matrix:
-        runner:
-          - blacksmith-8vcpu-ubuntu-2404
-          - blacksmith-staging-8vcpu-ubuntu-2404
+  python-tests-prod:
+    name: Python tests (prod)
     uses: ./.github/workflows/_python-tests.yml
     secrets: inherit
     with:
       property_testing_preset: 'normal'
-      runner: ${{ matrix.runner }}
+      runner: 'blacksmith-8vcpu-ubuntu-2404'
+
+  python-tests-staging:
+    name: Python tests (staging)
+    uses: ./.github/workflows/_python-tests.yml
+    secrets: inherit
+    with:
+      property_testing_preset: 'normal'
+      runner: 'blacksmith-staging-8vcpu-ubuntu-2404'
 
   python-vulnerability-scan:
     name: Python vulnerability scan
@@ -259,7 +261,8 @@ jobs:
   all-required-pr-checks-passed:
     if: always()
     needs:
-    - python-tests
+    - python-tests-prod
+    - python-tests-staging
     - python-vulnerability-scan
     - javascript-client-tests
     - rust-tests
@@ -274,13 +277,14 @@ jobs:
       uses: re-actors/alls-green@release/v1
       with:
         jobs: ${{ toJSON(needs) }}
-        allowed-skips: python-tests,python-vulnerability-scan,javascript-client-tests,rust-tests,rust-feature-tests,go-tests,check-helm-version-bump,delete-helm-comment
+        allowed-skips: python-tests-prod,python-tests-staging,python-vulnerability-scan,javascript-client-tests,rust-tests,rust-feature-tests,go-tests,check-helm-version-bump,delete-helm-comment
 
   notify-slack-on-failure:
     name: Notify Slack on Test Failure
     if: github.ref == 'refs/heads/main' && failure()
     needs:
-    - python-tests
+    - python-tests-prod
+    - python-tests-staging
     - python-vulnerability-scan
     - javascript-client-tests
     - rust-tests


### PR DESCRIPTION
## Summary
Testing Python tests workflow on both prod and staging blacksmith runners.

This PR is specifically to test if the "Start Tilt services" step completes on both runners.

## Changes
- Modified `.github/workflows/pr.yml` to run Python tests on a matrix of runners
- Updated `_python-tests.yml` to use the runner parameter in the cluster tests job
- Disabled all other test workflows for this branch

## Runners
- `blacksmith-8vcpu-ubuntu-2404` (prod)
- `blacksmith-staging-8vcpu-ubuntu-2404` (staging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)